### PR TITLE
MIVisionX - Changes to support relocatable ROCm installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ set(VERSION "1.6.0")
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
-set(CMAKE_INSTALL_PREFIX /opt/rocm/mivisionx)
+
+set(ROCM_PATH /opt/rocm CACHE PATH "default ROCm installation path")
+set(CMAKE_INSTALL_PREFIX ${ROCM_PATH}/mivisionx CACHE PATH "default MIVisionX installation path")
 
 if(NOT WIN32)
   string(ASCII 27 Esc)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -25,8 +25,8 @@ list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/../amd_openvx/cmake)
 
 find_package(OpenCV QUIET)
 find_package(OpenCL QUIET)
-find_package(miopengemm PATHS /opt/rocm QUIET)
-find_package(miopen     PATHS /opt/rocm QUIET)
+find_package(miopengemm PATHS ${ROCM_PATH} QUIET)
+find_package(miopen     PATHS ${ROCM_PATH} QUIET)
 
 if(OpenCL_FOUND AND miopengemm_FOUND AND miopen_FOUND)
     if(OpenCV_FOUND)


### PR DESCRIPTION
- Default package installation dir is set to /opt/rocm

Signed-off-by: Pruthvi Madugundu <pruthvi.madugundu@amd.com>