### PR TITLE
Setup Update - MIOpen Default - 2.5.0

### DIFF
--- a/MIVisionX-setup.py
+++ b/MIVisionX-setup.py
@@ -21,7 +21,7 @@
 __author__      = "Kiriti Nagesh Gowda"
 __copyright__   = "Copyright 2018 - 2020, AMD Radeon MIVisionX setup"
 __license__     = "MIT"
-__version__     = "1.7.11"
+__version__     = "1.7.12"
 __maintainer__  = "Kiriti Nagesh Gowda"
 __email__       = "Kiriti.NageshGowda@amd.com"
 __status__      = "Shipping"
@@ -38,7 +38,7 @@ import os
 parser = argparse.ArgumentParser()
 parser.add_argument('--directory', type=str, default='',        help='Setup home directory - optional (default:~/)')
 parser.add_argument('--installer', type=str, default='apt-get', help='Linux system installer - optional (default:apt-get) [options: Ubuntu - apt-get; CentOS - yum]')
-parser.add_argument('--miopen',    type=str, default='2.1.0',   help='MIOpen Version - optional (default:2.1.0)')
+parser.add_argument('--miopen',    type=str, default='2.5.0',   help='MIOpen Version - optional (default:2.5.0)')
 parser.add_argument('--miopengemm',type=str, default='1.1.5',   help='MIOpenGEMM Version - optional (default:1.1.5)')
 parser.add_argument('--protobuf',  type=str, default='3.12.0',  help='ProtoBuf Version - optional (default:3.12.0)')
 parser.add_argument('--ffmpeg',    type=str, default='no',      help='FFMPEG Installation - optional (default:no) [options:yes/no]')

--- a/README.md
+++ b/README.md
@@ -336,9 +336,9 @@ runvx /opt/rocm/mivisionx/samples/gdf/canny.gdf
 * ROCm: rocm-dkms - `3.3.0-19`
 * rocm-cmake - [github master:ac45c6e](https://github.com/RadeonOpenCompute/rocm-cmake/tree/master)
 * MIOpenGEMM - [1.1.5](https://github.com/ROCmSoftwarePlatform/MIOpenGEMM/releases/tag/1.1.5)
-* MIOpen - [2.1.0](https://github.com/ROCmSoftwarePlatform/MIOpen/releases/tag/2.1.0)
+* MIOpen - [2.5.0](https://github.com/ROCmSoftwarePlatform/MIOpen/releases/tag/2.5.0)
 * Protobuf - [V3.12.0](https://github.com/protocolbuffers/protobuf/releases/tag/v3.12.0)
 * OpenCV - [3.4.0](https://github.com/opencv/opencv/releases/tag/3.4.0)
 * RPP - [0.4](https://github.com/GPUOpen-ProfessionalCompute-Libraries/rpp/releases/tag/0.4)
 * Dependencies for all the above packages
-* MIVisionX Setup Script - V1.7.11
+* MIVisionX Setup Script - `V1.7.12`


### PR DESCRIPTION
* MIOpen Version upgrade - 2.5.0 to accommodate 3.6 ROCm changes.