### PR TITLE
Travis CI Updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,11 @@ branches:
 
 install:
   - sudo apt update
-  - sudo apt --yes install cmake git wget unzip libnuma-dev
-  - wget -qO - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
-  - sudo sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main > /etc/apt/sources.list.d/rocm.list'
-  - sudo apt update
-  - sudo apt install rocm-dkms
+  #- sudo apt --yes install cmake git wget unzip libnuma-dev
+  #- wget -qO - http://repo.radeon.com/rocm/apt/debian/rocm.gpg.key | sudo apt-key add -
+  #- sudo sh -c 'echo deb [arch=amd64] http://repo.radeon.com/rocm/apt/debian/ xenial main > /etc/apt/sources.list.d/rocm.list'
+  #- sudo apt update
+  #- sudo apt install rocm-dkms
 
 before_script:
   - docker pull kiritigowda/ubuntu-18.04:latest-mivisionx


### PR DESCRIPTION
Travis updates - remove ROCm install

* Hardware support on Travis for ROCm unknown. The docker has preinstalled all dependencies.
* No tests run to exercise the hardware