### PR TITLE
Setup - Boost shared and static lib

### DIFF
--- a/MIVisionX-setup.py
+++ b/MIVisionX-setup.py
@@ -25,7 +25,7 @@ import argparse
 __author__ = "Kiriti Nagesh Gowda"
 __copyright__ = "Copyright 2018 - 2020, AMD Radeon MIVisionX setup"
 __license__ = "MIT"
-__version__ = "1.8.3"
+__version__ = "1.8.4"
 __maintainer__ = "Kiriti Nagesh Gowda"
 __email__ = "Kiriti.NageshGowda@amd.com"
 __status__ = "Shipping"
@@ -207,6 +207,8 @@ else:
             '(cd '+deps_dir+'/boost_1_72_0/; ./b2 stage -j16 threading=multi link=shared )')
         os.system(
             '(cd '+deps_dir+'/boost_1_72_0/; sudo ./b2 install threading=multi link=shared --with-system --with-filesystem)')
+        os.system(
+            '(cd '+deps_dir+'/boost_1_72_0/; sudo ./b2 install threading=multi link=static --with-system --with-filesystem)')
         # Install half.hpp
         os.system(
             '(cd '+deps_dir+'; wget https://sourceforge.net/projects/half/files/half/1.12.0/half-1.12.0.zip )')

--- a/README.md
+++ b/README.md
@@ -399,4 +399,4 @@ sudo docker run -it --device=/dev/kfd --device=/dev/dri --cap-add=SYS_RAWIO --de
 * OpenCV - [3.4.0](https://github.com/opencv/opencv/releases/tag/3.4.0)
 * RPP - [0.5](https://github.com/GPUOpen-ProfessionalCompute-Libraries/rpp/releases/tag/0.5)
 * Dependencies for all the above packages
-* MIVisionX Setup Script - `V1.8.3`
+* MIVisionX Setup Script - `V1.8.4`


### PR DESCRIPTION
#369 - Failure due to boost static lib missing fixed

```
-- The C compiler identification is GNU 7.5.0
-- The CXX compiler identification is GNU 7.5.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Radeon Performance Primitives (RPP) Version -- 0.5
-- RPP install path set to -- /opt/rocm/rpp
-- cmake minimum version required: 3.5
-- cmake version found: 3.10.2
-- Clang tidy not found
-- Clang tidy checks: *,-cert-env33-c,-android-cloexec-fopen,-cert-msc30-c,-cert-msc50-cpp,-clang-analyzer-alpha.core.CastToStruct,-clang-analyzer-optin.performance.Padding,-clang-diagnostic-deprecated-declarations,-clang-diagnostic-extern-c-compat,-clang-diagnostic-unused-command-line-argument,-cppcoreguidelines-pro-bounds-array-to-pointer-decay,-cppcoreguidelines-pro-bounds-constant-array-index,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-cppcoreguidelines-pro-type-member-init,-cppcoreguidelines-pro-type-reinterpret-cast,-cppcoreguidelines-pro-type-union-access,-cppcoreguidelines-pro-type-vararg,-cppcoreguidelines-special-member-functions,-fuchsia-*,-google-explicit-constructor,-google-readability-braces-around-statements,-google-readability-todo,-google-runtime-int,-google-runtime-references,-hicpp-braces-around-statements,-hicpp-explicit-conversions,-hicpp-no-array-decay,-hicpp-signed-bitwise,-hicpp-special-member-functions,-hicpp-use-equals-default,-hicpp-use-override,-llvm-header-guard,-llvm-include-order,-misc-misplaced-const,-modernize-pass-by-value,-modernize-use-default-member-init,-modernize-use-equals-default,-modernize-use-transparent-functors,-performance-unnecessary-value-param,-readability-braces-around-statements,-readability-else-after-return,-readability-named-parameter,-hicpp-use-auto,-modernize-use-auto,-cppcoreguidelines-avoid-magic-numbers,-readability-magic-numbers,-cppcoreguidelines-macro-usage,-misc-non-private-member-variables-in-classes,-cppcoreguidelines-non-private-member-variables-in-classes,-readability-isolate-declaration,-cppcoreguidelines-avoid-c-arrays,-hicpp-avoid-c-arrays,-modernize-avoid-c-arrays,-readability-uppercase-literal-suffix,-hicpp-uppercase-literal-suffix,-cert-msc32-c,-cert-msc51-cpp,-bugprone-exception-escape
-- Found OPENCL: /opt/rocm/opencl/lib/libOpenCL.so  
-- extractkernel found: /opt/rocm/bin/extractkernel
Add Custome Command
OPenCL incude directories are /opt/rocm/opencl/include;/root/mivisionx-deps/rpp/src/include/cl/
-- amd_rpp built with ENABLE_SIMD_INTRINSICS
-- Boost  found.
-- Found Boost components:
   filesystem;system
-- Found OpenMP_C: -fopenmp (found version "4.5") 
-- Found OpenMP_CXX: -fopenmp (found version "4.5") 
-- Found OpenMP: TRUE (found version "4.5")  
-- CentOS detected   -- .rpm package will be created
-- Configuring done
-- Generating done
-- Build files have been written to: /root/mivisionx-deps/rpp/build
```