### PR TITLE
Updated x265 build instruction to skip cmake GUI

### DIFF
--- a/MIVisionX-setup.py
+++ b/MIVisionX-setup.py
@@ -417,7 +417,7 @@ else:
             # libx265
             os.system('(cd '+deps_dir+'; hg clone http://hg.videolan.org/x265 )')
             os.system(
-                '(cd '+deps_dir+'/x265/build/linux; ./make-Makefiles.bash; make -j8 )')
+                '(cd '+deps_dir+'/x265/build/linux; cmake -G "Unix Makefiles" ../../source; make -j8 )')
             os.system('sudo -v')
             os.system('(cd '+deps_dir+'/x265/build/linux; sudo ' +
                       linuxFlag+' make install; sudo '+linuxFlag+' ldconfig )')


### PR DESCRIPTION
ccmake command from 'make-Makefiles.bash' opens a cmake GUI and halts the installation.
replaced 'make-Makefiles.bash' with "cmake -G "Unix Makefiles" ../../source"