### PR TITLE
openVX HIP GPU backend - fix a bug for Graph.GraphState test

### DIFF
--- a/amd_openvx/openvx/ago/ago_interface.cpp
+++ b/amd_openvx/openvx/ago/ago_interface.cpp
@@ -2038,6 +2038,7 @@ static int agoWaitForNodesCompletion(AgoGraph * graph)
                 if (node->callback) {
                     vx_action action = node->callback(node);
                     if (action == VX_ACTION_ABANDON) {
+                        graph->state = VX_GRAPH_STATE_ABANDONED;
                         status = VX_ERROR_GRAPH_ABANDONED;
                         break;
                     }


### PR DESCRIPTION
set the graph state to VX_GRAPH_STATE_ABANDONED if the requested action is VX_ACTION_ABANDON