### PR TITLE
rocAL - pr513 override 

### DIFF
--- a/amd_openvx/openvx/hipvx/geometric_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/geometric_kernels.cpp
@@ -445,7 +445,7 @@ int HipExec_ScaleImage_U8_U8_Bilinear_Constant(hipStream_t stream, vx_uint32 dst
     hipLaunchKernelGGL(Hip_ScaleImage_U8_U8_Bilinear_Constant, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
                         (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcWidth, srcHeight,
-                        xscale, yscale, xoffset, yoffset, (uint) 0xaabbccdd);
+                        xscale, yscale, xoffset, yoffset, borderValue);
 
     return VX_SUCCESS;
 }

--- a/rocAL/rocAL/CMakeLists.txt
+++ b/rocAL/rocAL/CMakeLists.txt
@@ -23,6 +23,8 @@
 cmake_minimum_required(VERSION 3.0)
 project(rali)
 
+set(CMAKE_CXX_STANDARD 14)
+
 set(MIN_CMAKE_VER_REQUIRED 3.10)
 set(MIN_CXX_VER_REQUIRED 7.4)
 set(BUILD_RALI true)
@@ -124,7 +126,7 @@ if(${BUILD_RALI})
     else()
         target_compile_definitions(${PROJECT_NAME} PUBLIC ENABLE_OPENCV=0)
     endif()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fopenmp -msse4.2 -mavx2 -Wall -ljsoncpp -fPIC -pg -pthread")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fopenmp -msse4.2 -mavx2 -Wall -ljsoncpp -fPIC -pg -pthread -std=c++14")
     add_definitions(-ljsoncpp)
     message("-- ${Green}${PROJECT_NAME} - CMAKE_CXX_FLAGS:${CMAKE_CXX_FLAGS}")
 

--- a/rocAL/rocAL/include/master_graph.h
+++ b/rocAL/rocAL/include/master_graph.h
@@ -76,7 +76,7 @@ public:
     MetaDataBatch *create_caffe_lmdb_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type,  MetaDataType label_type);
     MetaDataBatch *create_caffe2_lmdb_record_meta_data_reader(const char *source_path, MetaDataReaderType reader_type,  MetaDataType label_type);
     MetaDataBatch* create_cifar10_label_reader(const char *source_path, const char *file_prefix);
-    void create_randombboxcrop_reader(RandomBBoxCrop_MetaDataReaderType reader_type, RandomBBoxCrop_MetaDataType label_type, bool all_boxes_overlap, bool no_crop, FloatParam* aspect_ratio, bool has_shape, int crop_width, int crop_height, int num_attempts, FloatParam* scaling, int total_num_attempts);
+    void create_randombboxcrop_reader(RandomBBoxCrop_MetaDataReaderType reader_type, RandomBBoxCrop_MetaDataType label_type, bool all_boxes_overlap, bool no_crop, FloatParam* aspect_ratio, bool has_shape, int crop_width, int crop_height, int num_attempts, FloatParam* scaling, int total_num_attempts, int64_t seed=0);
     const std::pair<ImageNameBatch,pMetaDataBatch>& meta_data();
     void set_loop(bool val) { _loop = val; }
     bool empty() { return (remaining_images_count() < _user_batch_size); }

--- a/rocAL/rocAL/include/meta_data.h
+++ b/rocAL/rocAL/include/meta_data.h
@@ -28,7 +28,7 @@ THE SOFTWARE.
 #include "commons.h"
 
 
-typedef  struct { float x; float y; float w; float h; } BoundingBoxCord;
+typedef  struct { float l; float t; float r; float b; } BoundingBoxCord;
 typedef  std::vector<BoundingBoxCord> BoundingBoxCords;
 typedef  std::vector<int> BoundingBoxLabels;
 typedef  struct { int w; int h; } ImgSize;

--- a/rocAL/rocAL/include/meta_node.h
+++ b/rocAL/rocAL/include/meta_node.h
@@ -48,15 +48,8 @@ inline double MetaNode::BBoxIntersectionOverUnion(const BoundingBoxCord &box1, c
     float yB = std::min(box1.b, box2.b);
 
     float intersection_area = std::max((float)0.0, xB - xA) * std::max((float)0.0, yB - yA);
-    float box1_h, box1_w, box2_h, box2_w;
-    box1_w = box1.r - box1.l;
-    box2_w = box2.r - box2.l;
-    box1_h = box1.b - box1.t;
-    box2_h = box2.b - box2.t;
-
-
-    float box1_area = box1_h * box1_w;
-    float box2_area = box2_h * box2_w;
+    float box1_area = (box1.b - box1.t) * (box1.r - box1.l);
+    float box2_area = (box2.b - box2.t) * (box2.r - box2.l);
 
     if (is_iou)
         iou = intersection_area / float(box1_area + box2_area - intersection_area);

--- a/rocAL/rocAL/include/meta_node.h
+++ b/rocAL/rocAL/include/meta_node.h
@@ -42,17 +42,23 @@ public:
 inline double MetaNode::BBoxIntersectionOverUnion(const BoundingBoxCord &box1, const BoundingBoxCord &box2, bool is_iou = false) const
 {
     double iou;
-    float xA = std::max(box1.x, box2.x);
-    float yA = std::max(box1.y, box2.y);
-    float xB = std::min(box1.x + box1.w, box2.x + box2.w);
-    float yB = std::min(box1.y + box1.h, box2.y + box2.h);
+    float xA = std::max(box1.l, box2.l);
+    float yA = std::max(box1.t, box2.t);
+    float xB = std::min(box1.r, box2.r);
+    float yB = std::min(box1.b, box2.b);
 
     float intersection_area = std::max((float)0.0, xB - xA) * std::max((float)0.0, yB - yA);
+    float box1_h, box1_w, box2_h, box2_w;
+    box1_w = box1.r - box1.l;
+    box2_w = box2.r - box2.l;
+    box1_h = box1.b - box1.t;
+    box2_h = box2.b - box2.t;
 
-    float box1_area = box1.h * box1.w;
-    float box2_area = box2.h * box2.w;
 
-    if(is_iou)
+    float box1_area = box1_h * box1_w;
+    float box2_area = box2_h * box2_w;
+
+    if (is_iou)
         iou = intersection_area / float(box1_area + box2_area - intersection_area);
     else
         iou = intersection_area / float(box1_area);

--- a/rocAL/rocAL/include/meta_node_crop_mirror_normalize.h
+++ b/rocAL/rocAL/include/meta_node_crop_mirror_normalize.h
@@ -37,6 +37,6 @@ class CropMirrorNormalizeMetaNode:public MetaNode
     private:
         void initialize();
         std::shared_ptr<RaliCropParam> _meta_crop_param;
-        vx_array _dstImgWidth, _dstImgHeight, _x1, _y1, _mirror;
-        std::vector<uint> _width_val, _height_val, _x1_val, _y1_val, _mirror_val;
+        vx_array _dstImgWidth, _dstImgHeight, _x1, _y1, _mirror, _src_width, _src_height;
+        std::vector<uint> _width_val, _height_val, _x1_val, _y1_val, _mirror_val,_src_width_val,_src_height_val;
 };

--- a/rocAL/rocAL/include/node_crop_mirror_normalize.h
+++ b/rocAL/rocAL/include/node_crop_mirror_normalize.h
@@ -34,12 +34,13 @@ public:
     void init(int crop_h, int crop_w, float start_x, float start_y, float mean, float std_dev, IntParam *mirror);
     vx_array return_mirror(){ return _mirror.default_array();  }
     std::shared_ptr<RaliCropParam> return_crop_param() { return _crop_param; }
+    vx_array get_src_width() { return _src_roi_width; }
+    vx_array get_src_height() { return _src_roi_height; }
 protected:
     void create_node() override ;
     void update_node() override;
 private:
     std::shared_ptr<RaliCropParam> _crop_param;
-    vx_array _src_width_array, _src_height_array;
     std::vector<vx_float32> _mean_vx, _std_dev_vx;
     vx_array _mean_array, _std_dev_array;
     float _mean; 

--- a/rocAL/rocAL/include/rali_api_meta_data.h
+++ b/rocAL/rocAL/include/rali_api_meta_data.h
@@ -124,7 +124,7 @@ extern "C" RaliMetaData RALI_API_CALL raliCreateTextCifar10LabelReader(RaliConte
 /// \param numOfClasses the number of classes for a image dataset
 /// \param buf user's buffer that will be filled with labels. Its needs to be at least of size batch_size.
 extern "C" void RALI_API_CALL raliGetOneHotImageLabels(RaliContext rali_context,int *buf, int numOfClasses);
-extern "C" void RALI_API_CALL raliRandomBBoxCrop(RaliContext p_context, bool all_boxes_overlap, bool no_crop, RaliFloatParam aspect_ratio = NULL, bool has_shape = false, int crop_width = 0, int crop_height = 0, int num_attempts = 1, RaliFloatParam scaling = NULL, int total_num_attempts = 0);
+extern "C" void RALI_API_CALL raliRandomBBoxCrop(RaliContext p_context, bool all_boxes_overlap, bool no_crop, RaliFloatParam aspect_ratio = NULL, bool has_shape = false, int crop_width = 0, int crop_height = 0, int num_attempts = 1, RaliFloatParam scaling = NULL, int total_num_attempts = 0, int64_t seed = 0);
 
 
 #endif //MIVISIONX_RALI_API_META_DATA_H

--- a/rocAL/rocAL/include/randombboxcrop_meta_data.h
+++ b/rocAL/rocAL/include/randombboxcrop_meta_data.h
@@ -32,22 +32,23 @@ struct CropCord
 {
     CropCord()
     {
-        crop_x = 0;
-        crop_y = 0;
-        crop_width = 0;
-        crop_height = 0;
+        crop_left = 0;
+        crop_top = 0;
+        crop_right = 0;
+        crop_bottom = 0;
     }
-    CropCord(float x, float y, float c_w, float c_h)
+    CropCord(float l, float t, float r, float b)
     {
-        crop_x = x;
-        crop_y = y;
-        crop_width = c_w;
-        crop_height = c_h;
+        crop_left = l;
+        crop_top = t;
+        crop_right= r;
+        crop_bottom = b;
+        
     }
-    float crop_x;
-    float crop_y;
-    float crop_width;
-    float crop_height;
+    float crop_left;
+    float crop_top;
+    float crop_right;
+    float crop_bottom;
 };
 
 using pCropCord = std::shared_ptr<CropCord>;

--- a/rocAL/rocAL/include/randombboxcrop_meta_data_reader.h
+++ b/rocAL/rocAL/include/randombboxcrop_meta_data_reader.h
@@ -53,10 +53,12 @@ private:
     int _num_attempts;
     FloatParam* _scaling;
     int _total_num_attempts;
+    int64_t _seed;
 public:
     RandomBBoxCrop_MetaDataConfig(const RandomBBoxCrop_MetaDataType& type, const RandomBBoxCrop_MetaDataReaderType& reader_type, const bool& all_boxes_overlap,
-                        const bool& no_crop, FloatParam* aspect_ratio, const bool& has_shape, const int& crop_width, const int& crop_height, const int& num_attempts, FloatParam* scaling, const int& total_num_attempts):  _type(type), _reader_type(reader_type),
-                        _all_boxes_overlap(all_boxes_overlap), _no_crop(no_crop), _aspect_ratio(aspect_ratio) ,_has_shape(has_shape), _crop_width(crop_width), _crop_height(crop_height), _num_attempts(num_attempts), _scaling(scaling), _total_num_attempts(total_num_attempts){}
+                        const bool& no_crop, FloatParam* aspect_ratio, const bool& has_shape, const int& crop_width, const int& crop_height, const int& num_attempts,
+                        FloatParam* scaling, const int& total_num_attempts, const int64_t& seed):  _type(type), _reader_type(reader_type), _all_boxes_overlap(all_boxes_overlap), _no_crop(no_crop), _aspect_ratio(aspect_ratio),
+                        _has_shape(has_shape), _crop_width(crop_width), _crop_height(crop_height), _num_attempts(num_attempts), _scaling(scaling), _total_num_attempts(total_num_attempts), _seed(seed){}
     RandomBBoxCrop_MetaDataConfig() = delete;
     RandomBBoxCrop_MetaDataType type() const { return _type; }
     RandomBBoxCrop_MetaDataReaderType reader_type() const { return _reader_type; }
@@ -69,6 +71,7 @@ public:
     FloatParam* scaling() const { return _scaling; }
     int num_attempts() const { return _num_attempts; }
     int total_num_attempts() const { return _total_num_attempts; }
+    int seed() const { return _seed; }
 };
 
 class RandomBBoxCrop_MetaDataReader

--- a/rocAL/rocAL/include/randombboxcrop_reader.h
+++ b/rocAL/rocAL/include/randombboxcrop_reader.h
@@ -30,6 +30,41 @@ THE SOFTWARE.
 #include "parameter_crop_factory.h"
 #include "meta_data_reader.h"
 #include "coco_meta_data_reader.h"
+#include <random>
+
+// todo:: move this to common header
+template<typename T = std::mt19937, std::size_t state_size = T::state_size>
+class SeededRNG {
+  /*
+  * @param batch_size How many RNGs to store
+  * @param state_size How many seed are used to initialize one RNG. Used to lower probablity of
+  * collisions between seeds used to initialize RNGs in different operators.
+  */
+public: 
+  SeededRNG (int batch_size = 128) {
+      std::random_device source;
+      _batch_size = batch_size;
+      std::size_t _random_data_size = state_size * batch_size ;
+      std::vector<std::random_device::result_type> random_data(_random_data_size);
+      std::generate(random_data.begin(), random_data.end(), std::ref(source));
+      _rngs.reserve(batch_size);
+      for (int i=0; i < (int)(_batch_size*state_size); i += state_size) {
+        std::seed_seq seeds(std::begin(random_data) + i, std::begin(random_data)+ i +state_size);
+        _rngs.emplace_back(T(seeds));
+      }
+  }
+
+  /**
+   * Returns engine corresponding to given sample ID
+   */
+   T &operator[](int sample) noexcept {
+    return _rngs[sample % _batch_size];
+  }
+
+private:
+    std::vector<T> _rngs;
+    int _batch_size;
+};
 
 class RandomBBoxCropReader: public RandomBBoxCrop_MetaDataReader
 {
@@ -41,42 +76,30 @@ public:
     void print_map_contents();
     void update_meta_data();
     CropCordBatch * get_output() override { return _output; }
-    std::shared_ptr<RaliRandomCropParam> get_crop_param() { return _crop_param; }
-    float get_threshold(){return _threshold;}
-    std::vector<std::pair<bool, float>> get_iou_range(){return _iou_range;}
     bool is_entire_iou(){return _entire_iou;}
     void set_meta_data(std::shared_ptr<MetaDataReader> meta_data_reader) override;
     pCropCord get_crop_cord(const std::string &image_names) override;
     RandomBBoxCropReader();
     ~RandomBBoxCropReader() override {}
+
 private:
-    std::shared_ptr<RaliRandomCropParam> _meta_crop_param;
     std::shared_ptr<COCOMetaDataReader> _meta_data_reader = nullptr;
     std::map<std::string, std::shared_ptr<BoundingBox>> _meta_bbox_map_content;
-    std::vector<uint> _crop_width_val, _crop_height_val, _x1_val, _y1_val, _x2_val, _y2_val;
-    std::vector<uint32_t> in_width, in_height;
-    float  _threshold = 0.05;
-    int _batch_size = 1;
-    std::vector<std::pair<bool, float>> _iou_range;
     bool _all_boxes_overlap;
     bool _no_crop;
     bool _has_shape;
-    int _crop_width;
-    int _crop_height;
     int _num_of_attempts = 20;
     int _total_num_of_attempts = 0;
     bool _entire_iou = false;
     FloatParam *crop_area_factor = NULL;
     FloatParam *crop_aspect_ratio = NULL;
-    constexpr static float ASPECT_RATIO_RANGE [2] = {0.5, 2.0};
-    FloatParam *x_drift = NULL;
-    FloatParam *y_drift = NULL;
-    std::shared_ptr<RaliRandomCropParam> _crop_param;
+    int _user_batch_size;
+    int64_t _seed;
     void add(std::string image_name, BoundingBoxCord bbox);
     bool exists(const std::string &image_name);
     std::map<std::string, std::shared_ptr<CropCord>> _map_content;
     std::map<std::string, std::shared_ptr<CropCord>>::iterator _itr;
     std::shared_ptr<Graph> _graph = nullptr;
     CropCordBatch* _output;
+    SeededRNG<std::mt19937, 4> _rngs;     // setting the state_size to 4 for 4 random parameters.
 };
-

--- a/rocAL/rocAL/source/bounding_box_graph.cpp
+++ b/rocAL/rocAL/source/bounding_box_graph.cpp
@@ -110,10 +110,10 @@ void BoundingBoxGraph::update_random_bbox_meta_data(CropCordBatch *_random_bbox_
         BoundingBoxCords bb_coords;
         BoundingBoxLabels bb_labels;
         BoundingBoxCord crop_box;
-        crop_box.x = crop_cords[i]->crop_x;
-        crop_box.y = crop_cords[i]->crop_y;
-        crop_box.w = crop_cords[i]->crop_width;
-        crop_box.h = crop_cords[i]->crop_height;
+        crop_box.x = (crop_cords[i]->crop_x) / float(original_width[i]);
+        crop_box.y = (crop_cords[i]->crop_y) / float(original_height[i]);
+        crop_box.w = (crop_cords[i]->crop_width) / float(original_width[i]);
+        crop_box.h = (crop_cords[i]->crop_height) / float(original_height[i]);
         for (uint j = 0; j < bb_count; j++)
         {
             int m = j * 4; // change if required
@@ -137,10 +137,10 @@ void BoundingBoxGraph::update_random_bbox_meta_data(CropCordBatch *_random_bbox_
                 float yA = std::max(crop_box.y, box.y);
                 float xB = std::min(crop_box.x + crop_box.w, box.x + box.w);
                 float yB = std::min(crop_box.y + crop_box.h, box.y + box.h);
-                box.x = xA - crop_box.x;
-                box.y = yA - crop_box.y;
-                box.w = xB - xA;
-                box.h = yB - yA;
+                box.x = (xA - crop_box.x) / crop_box.w;
+                box.y = (yA - crop_box.y) / crop_box.h;
+                box.w = (xB - xA) / crop_box.w;
+                box.h = (yB - yA) / crop_box.h;
 
                 bb_coords.push_back(box);
                 bb_labels.push_back(labels_buf[j]);
@@ -149,6 +149,7 @@ void BoundingBoxGraph::update_random_bbox_meta_data(CropCordBatch *_random_bbox_
         if (bb_coords.size() == 0)
         {
             std::cerr << "Bounding box co-ordinates not found in the image";
+	    break;
         }
         input_meta_data->get_bb_cords_batch()[i] = bb_coords;
         input_meta_data->get_bb_labels_batch()[i] = bb_labels;

--- a/rocAL/rocAL/source/bounding_box_graph.cpp
+++ b/rocAL/rocAL/source/bounding_box_graph.cpp
@@ -119,9 +119,9 @@ void BoundingBoxGraph::update_random_bbox_meta_data(CropCordBatch *_random_bbox_
             int m = j * 4; // change if required
 
             //Mask Criteria
-            auto left = int(crop_box.x);
+            auto left = crop_box.x;
             auto top = crop_box.y;
-            auto right = int(crop_box.x) + int(crop_box.w);
+            auto right = crop_box.x + crop_box.w;
             auto bottom = crop_box.y + crop_box.h;
 
             BoundingBoxCord box;
@@ -129,8 +129,8 @@ void BoundingBoxGraph::update_random_bbox_meta_data(CropCordBatch *_random_bbox_
             box.y = coords_buf[m + 1];
             box.w = coords_buf[m + 2];
             box.h = coords_buf[m + 3];
-            auto x_c = 0.5f * (2 * box.x + box.w);
-            auto y_c = 0.5f * (2 * box.y + box.h);
+            auto x_c = box.x + 0.5f * box.w;
+            auto y_c = box.y + 0.5f * box.h;
             if ((x_c > left) && (x_c < right) && (y_c > top) && (y_c < bottom))
             {
                 float xA = std::max(crop_box.x, box.x);
@@ -143,7 +143,7 @@ void BoundingBoxGraph::update_random_bbox_meta_data(CropCordBatch *_random_bbox_
                 box.h = yB - yA;
 
                 bb_coords.push_back(box);
-                bb_labels.push_back(labels_buf[j]);                
+                bb_labels.push_back(labels_buf[j]);
             }
         }
         if (bb_coords.size() == 0)

--- a/rocAL/rocAL/source/bounding_box_graph.cpp
+++ b/rocAL/rocAL/source/bounding_box_graph.cpp
@@ -111,20 +111,16 @@ void BoundingBoxGraph::update_random_bbox_meta_data(CropCordBatch *_random_bbox_
         crop_box.t = crop_cords[i]->crop_top;
         crop_box.r = crop_cords[i]->crop_right;
         crop_box.b = crop_cords[i]->crop_bottom;
-    //    std::cout<<"CROP Co-ordinates in bounding box grpah: lxtxrxb::\t"<<crop_box.l<<"x\t"<<crop_box.t<<"x\t"<<crop_box.r<<"x\t"<<crop_box.b<<"x\t"<<std::endl;
 
         for (uint j = 0; j < bb_count; j++)
         {
             int m = j * 4; // change if required
-
             //Mask Criteria
-
             BoundingBoxCord box;
             box.l = coords_buf[m];
             box.t = coords_buf[m + 1];
             box.r = coords_buf[m + 2];
             box.b = coords_buf[m + 3];
-
             auto x_c = 0.5 * (box.l + box.r);
             auto y_c = 0.5 * (box.t + box.b);
             if ((x_c > crop_box.l) && (x_c < crop_box.r) && (y_c > crop_box.t) && (y_c < crop_box.b))

--- a/rocAL/rocAL/source/bounding_box_graph.cpp
+++ b/rocAL/rocAL/source/bounding_box_graph.cpp
@@ -46,19 +46,19 @@ void BoundingBoxGraph::update_meta_data(MetaDataBatch *input_meta_data, decoded_
         memcpy(coords_buf.data(), input_meta_data->get_bb_cords_batch()[i].data(), input_meta_data->get_bb_cords_batch()[i].size() * sizeof(BoundingBoxCord));
         BoundingBoxCords bb_coords;
         BoundingBoxCord temp_box;
-        temp_box.x = temp_box.y = temp_box.w = temp_box.h = 0;
+        temp_box.l = temp_box.t = temp_box.r = temp_box.b = 0;
         BoundingBoxLabels bb_labels;
         int m = 0;
         for (uint j = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
-            float temp_x, temp_y;
-            temp_x = (coords_buf[m++] * _dst_to_src_width_ratio);
-            temp_y = (coords_buf[m++] * _dst_to_src_height_ratio);
-            box.x = (temp_x > 0) ? temp_x : 0;
-            box.y = (temp_y > 0) ? temp_y : 0;
-            box.w = (coords_buf[m++] * _dst_to_src_width_ratio);
-            box.h = (coords_buf[m++] * _dst_to_src_height_ratio);
+            float temp_l, temp_t;
+            temp_l = (coords_buf[m++] * _dst_to_src_width_ratio);
+            temp_t = (coords_buf[m++] * _dst_to_src_height_ratio);
+            box.l = (temp_l > 0) ? temp_l : 0;
+            box.t = (temp_t > 0) ? temp_t : 0;
+            box.r = (coords_buf[m++] * _dst_to_src_width_ratio);
+            box.b = (coords_buf[m++] * _dst_to_src_height_ratio);
             bb_coords.push_back(box);
             bb_labels.push_back(labels_buf[j]);
         }
@@ -72,18 +72,23 @@ void BoundingBoxGraph::update_meta_data(MetaDataBatch *input_meta_data, decoded_
     }
 }
 
-inline double BBoxIntersectionOverUnion(const BoundingBoxCord &box1, const BoundingBoxCord &box2, bool is_iou = false)
+inline double ssd_BBoxIntersectionOverUnion(const BoundingBoxCord &box1, const BoundingBoxCord &box2, bool is_iou = false)
 {
     double iou;
-    float xA = std::max(box1.x, box2.x);
-    float yA = std::max(box1.y, box2.y);
-    float xB = std::min(box1.x + box1.w, box2.x + box2.w);
-    float yB = std::min(box1.y + box1.h, box2.y + box2.h);
+    float xA = std::max(box1.l, box2.l);
+    float yA = std::max(box1.t, box2.t);
+    float xB = std::min(box1.r, box2.r);
+    float yB = std::min(box1.b, box2.b);
 
     float intersection_area = std::max((float)0.0, xB - xA) * std::max((float)0.0, yB - yA);
+    float box1_h, box1_w, box2_h, box2_w;
+    box1_w = box1.r - box1.l;
+    box2_w = box2.r - box2.l;
+    box1_h = box1.b - box1.t;
+    box2_h = box2.b - box2.t;
 
-    float box1_area = box1.h * box1.w;
-    float box2_area = box2.h * box2.w;
+    float box1_area = box1_h * box1_w;
+    float box2_area = box2_h * box2_w;
 
     if (is_iou)
         iou = intersection_area / float(box1_area + box2_area - intersection_area);
@@ -110,37 +115,37 @@ void BoundingBoxGraph::update_random_bbox_meta_data(CropCordBatch *_random_bbox_
         BoundingBoxCords bb_coords;
         BoundingBoxLabels bb_labels;
         BoundingBoxCord crop_box;
-        crop_box.x = (crop_cords[i]->crop_x) / float(original_width[i]);
-        crop_box.y = (crop_cords[i]->crop_y) / float(original_height[i]);
-        crop_box.w = (crop_cords[i]->crop_width) / float(original_width[i]);
-        crop_box.h = (crop_cords[i]->crop_height) / float(original_height[i]);
+        crop_box.l = crop_cords[i]->crop_left;
+        crop_box.t = crop_cords[i]->crop_top;
+        crop_box.r = crop_cords[i]->crop_right;
+        crop_box.b = crop_cords[i]->crop_bottom;
+    //    std::cout<<"CROP Co-ordinates in bounding box grpah: lxtxrxb::\t"<<crop_box.l<<"x\t"<<crop_box.t<<"x\t"<<crop_box.r<<"x\t"<<crop_box.b<<"x\t"<<std::endl;
+
         for (uint j = 0; j < bb_count; j++)
         {
             int m = j * 4; // change if required
 
             //Mask Criteria
-            auto left = crop_box.x;
-            auto top = crop_box.y;
-            auto right = crop_box.x + crop_box.w;
-            auto bottom = crop_box.y + crop_box.h;
 
             BoundingBoxCord box;
-            box.x = coords_buf[m];
-            box.y = coords_buf[m + 1];
-            box.w = coords_buf[m + 2];
-            box.h = coords_buf[m + 3];
-            auto x_c = box.x + 0.5f * box.w;
-            auto y_c = box.y + 0.5f * box.h;
-            if ((x_c > left) && (x_c < right) && (y_c > top) && (y_c < bottom))
+            box.l = coords_buf[m];
+            box.t = coords_buf[m + 1];
+            box.r = coords_buf[m + 2];
+            box.b = coords_buf[m + 3];
+
+            auto x_c = 0.5 * (box.l + box.r);
+            auto y_c = 0.5 * (box.t + box.b);
+            if ((x_c > crop_box.l) && (x_c < crop_box.r) && (y_c > crop_box.t) && (y_c < crop_box.b))
             {
-                float xA = std::max(crop_box.x, box.x);
-                float yA = std::max(crop_box.y, box.y);
-                float xB = std::min(crop_box.x + crop_box.w, box.x + box.w);
-                float yB = std::min(crop_box.y + crop_box.h, box.y + box.h);
-                box.x = (xA - crop_box.x) / crop_box.w;
-                box.y = (yA - crop_box.y) / crop_box.h;
-                box.w = (xB - xA) / crop_box.w;
-                box.h = (yB - yA) / crop_box.h;
+                float xA = std::max(crop_box.l, box.l);
+                float yA = std::max(crop_box.t, box.t);
+                float xB = std::min(crop_box.r, box.r);
+                float yB = std::min(crop_box.b, box.b);
+                box.l = (xA - crop_box.l) / (crop_box.r - crop_box.l);
+                box.t = (yA - crop_box.t) / (crop_box.b - crop_box.t);
+                box.r = (xB - crop_box.l) / (crop_box.r - crop_box.l);
+                box.b = (yB - crop_box.t) / (crop_box.b - crop_box.t);
+                // std::cout<<"\nn bounding box grpah: Box Co-ordinates lxtxrxb::\t"<<box.l<<"x\t"<<box.t<<"x\t"<<box.r<<"x\t"<<box.b<<"x\t"<<std::endl;
 
                 bb_coords.push_back(box);
                 bb_labels.push_back(labels_buf[j]);
@@ -149,7 +154,7 @@ void BoundingBoxGraph::update_random_bbox_meta_data(CropCordBatch *_random_bbox_
         if (bb_coords.size() == 0)
         {
             std::cerr << "Bounding box co-ordinates not found in the image";
-	    break;
+            exit(0);
         }
         input_meta_data->get_bb_cords_batch()[i] = bb_coords;
         input_meta_data->get_bb_labels_batch()[i] = bb_labels;

--- a/rocAL/rocAL/source/caffe2_meta_data_reader_detection.cpp
+++ b/rocAL/rocAL/source/caffe2_meta_data_reader_detection.cpp
@@ -182,11 +182,11 @@ void Caffe2MetaDataReaderDetection::read_lmdb_record(std::string file_name, uint
                 for (int i = 0; i < boundBox_size / 4; i++)
                 {
                     // Parsing the bounding box points using Iterator 
-                    //YTD: Normalize the Bboxes
-                    box.l = boundingBox_proto.dims(boundIter);
-                    box.t = boundingBox_proto.dims(boundIter + 1);
-                    box.r = boundingBox_proto.dims(boundIter + 2);
-                    box.b = boundingBox_proto.dims(boundIter + 3);
+                    // && Normalizing the box Co-ordinates
+                    box.l = boundingBox_proto.dims(boundIter) / img_size.w;
+                    box.t = boundingBox_proto.dims(boundIter + 1) / img_size.h;
+                    box.r = boundingBox_proto.dims(boundIter + 2) / img_size.w;
+                    box.b = boundingBox_proto.dims(boundIter + 3) / img_size.h;
 
                     boundIter += 4;
 
@@ -202,7 +202,8 @@ void Caffe2MetaDataReaderDetection::read_lmdb_record(std::string file_name, uint
             }
             else
             {
-                box.l = box.t = box.r = box.b = 0;
+                box.l = box.t = 0;
+                box.r = box.b = 1;
                 bb_coords.push_back(box);
                 bb_labels.push_back(0);
                 add(str_key.c_str(), bb_coords, bb_labels,img_sizes);

--- a/rocAL/rocAL/source/caffe2_meta_data_reader_detection.cpp
+++ b/rocAL/rocAL/source/caffe2_meta_data_reader_detection.cpp
@@ -93,7 +93,7 @@ void Caffe2MetaDataReaderDetection::print_map_contents()
         std::cerr << "\nsize of the element  : " << bb_coords.size() << std::endl;
         for (unsigned int i = 0; i < bb_coords.size(); i++)
         {
-            std::cerr << " x : " << bb_coords[i].x << " y: :" << bb_coords[i].y << " width : " << bb_coords[i].w << " height: :" << bb_coords[i].h << std::endl;
+            std::cerr << " l : " << bb_coords[i].l << " t: :" << bb_coords[i].t << " r : " << bb_coords[i].r << " b: :" << bb_coords[i].b << std::endl;
             std::cerr << "Label Id : " << bb_labels[i] << std::endl;
         }
     }
@@ -181,11 +181,13 @@ void Caffe2MetaDataReaderDetection::read_lmdb_record(std::string file_name, uint
                 int boundIter = 0;
                 for (int i = 0; i < boundBox_size / 4; i++)
                 {
-                    // Parsing the bounding box points using Iterator
-                    box.x = boundingBox_proto.dims(boundIter);
-                    box.y = boundingBox_proto.dims(boundIter + 1);
-                    box.w = boundingBox_proto.dims(boundIter + 2);
-                    box.h = boundingBox_proto.dims(boundIter + 3);
+                    // Parsing the bounding box points using Iterator 
+                    //YTD: Normalize the Bboxes
+                    box.l = boundingBox_proto.dims(boundIter);
+                    box.t = boundingBox_proto.dims(boundIter + 1);
+                    box.r = boundingBox_proto.dims(boundIter + 2);
+                    box.b = boundingBox_proto.dims(boundIter + 3);
+
                     boundIter += 4;
 
                     // Parsing the image label using Iterator
@@ -200,7 +202,7 @@ void Caffe2MetaDataReaderDetection::read_lmdb_record(std::string file_name, uint
             }
             else
             {
-                box.x = box.y = box.w = box.h = 0;
+                box.l = box.t = box.r = box.b = 0;
                 bb_coords.push_back(box);
                 bb_labels.push_back(0);
                 add(str_key.c_str(), bb_coords, bb_labels,img_sizes);

--- a/rocAL/rocAL/source/caffe_meta_data_reader_detection.cpp
+++ b/rocAL/rocAL/source/caffe_meta_data_reader_detection.cpp
@@ -94,7 +94,7 @@ void CaffeMetaDataReaderDetection::print_map_contents()
         std::cerr << "\nsize of the element  : " << bb_coords.size() << std::endl;
         for (unsigned int i = 0; i < bb_coords.size(); i++)
         {
-            std::cerr << " x : " << bb_coords[i].x << " y: :" << bb_coords[i].y << " width : " << bb_coords[i].w << " height: :" << bb_coords[i].h << std::endl;
+            std::cerr << " l : " << bb_coords[i].l << " t: :" << bb_coords[i].t << " r : " << bb_coords[i].r << " b: :" << bb_coords[i].b << std::endl;
             std::cerr << "Label Id : " << bb_labels[i] << std::endl;
         }
     }
@@ -168,11 +168,11 @@ void CaffeMetaDataReaderDetection::read_lmdb_record(std::string file_name, uint 
                 caffe_protos::Annotation annot_protos = annotGrp_protos.annotation(i);
                 caffe_protos::NormalizedBBox bbox_protos = annot_protos.bbox();
 
-                // Parsing the bounding box points using Iterator
-                box.x = bbox_protos.xmin();
-                box.y = bbox_protos.ymin();
-                box.w = bbox_protos.xmax();
-                box.h = bbox_protos.ymax();
+                // Parsing the bounding box points using Iterator & normalizing the bbox values between 0 & 1
+                box.l = bbox_protos.xmin() / img_size.w;
+                box.t = bbox_protos.ymin() / img_size.h;
+                box.r = bbox_protos.xmax() / img_size.w;
+                box.b = bbox_protos.ymax() / img_size.h;
 
                 int label = bbox_protos.label();
                 
@@ -185,7 +185,8 @@ void CaffeMetaDataReaderDetection::read_lmdb_record(std::string file_name, uint 
         }
         else
         {
-            box.x = box.y = box.w = box.h = 0;
+            box.l = box.t = 0;
+            box.r = box.b = 1;
             bb_coords.push_back(box);
             bb_labels.push_back(0);
             add(file_name.c_str(), bb_coords, bb_labels, img_sizes);

--- a/rocAL/rocAL/source/caffe_meta_data_reader_detection.cpp
+++ b/rocAL/rocAL/source/caffe_meta_data_reader_detection.cpp
@@ -54,7 +54,7 @@ void CaffeMetaDataReaderDetection::add(std::string image_name, BoundingBoxCords 
         it->second->get_bb_labels().push_back(bb_labels[0]);
         return;
     }
-    pMetaDataBox info = std::make_shared<BoundingBox>(bb_coords, bb_labels,image_size);
+    pMetaDataBox info = std::make_shared<BoundingBox>(bb_coords, bb_labels, image_size);
     _map_content.insert(pair<std::string, std::shared_ptr<BoundingBox>>(image_name, info));
 }
 
@@ -175,7 +175,7 @@ void CaffeMetaDataReaderDetection::read_lmdb_record(std::string file_name, uint 
                 box.b = bbox_protos.ymax() / img_size.h;
 
                 int label = bbox_protos.label();
-                
+
                 bb_coords.push_back(box);
                 bb_labels.push_back(label);
                 add(file_name.c_str(), bb_coords, bb_labels, img_sizes);

--- a/rocAL/rocAL/source/coco_meta_data_reader.cpp
+++ b/rocAL/rocAL/source/coco_meta_data_reader.cpp
@@ -89,7 +89,7 @@ void COCOMetaDataReader::print_map_contents()
         img_sizes = elem.second->get_img_sizes();
         std::cout << "<wxh, num of bboxes>: "<< img_sizes[0].w << " X " << img_sizes[0].h << " , "  << bb_coords.size() << std::endl;
         for(unsigned int i = 0; i < bb_coords.size(); i++){
-            std::cout << " x : " << bb_coords[i].x << " y: :" << bb_coords[i].y << " width : " << bb_coords[i].w << " height: :" << bb_coords[i].h << "Label Id : " << bb_labels[i] << std::endl;
+            std::cout << " l : " << bb_coords[i].l << " t: :" << bb_coords[i].t << " r : " << bb_coords[i].r << " b: :" << bb_coords[i].b << "Label Id : " << bb_labels[i] << std::endl;
         }
     }
 }
@@ -117,7 +117,7 @@ void COCOMetaDataReader::read_all(const std::string &path) {
 
     BoundingBoxCord box;
     ImgSize img_size;
-    
+    float box_x, box_y, box_w, box_h;
     for (auto iterator = image.begin(); iterator != image.end(); iterator++)
     {
         // std::map<int, int,int> id_img_sizes;
@@ -133,10 +133,10 @@ void COCOMetaDataReader::read_all(const std::string &path) {
     
     for (auto iterator = annotation.begin(); iterator != annotation.end(); iterator++)
     {
-        box.x = (*iterator)["bbox"][0].asFloat();
-        box.y = (*iterator)["bbox"][1].asFloat();
-        box.w = (*iterator)["bbox"][2].asFloat();
-        box.h = (*iterator)["bbox"][3].asFloat();
+        box_x = (*iterator)["bbox"][0].asFloat();
+        box_y = (*iterator)["bbox"][1].asFloat();
+        box_w = (*iterator)["bbox"][2].asFloat();
+        box_h = (*iterator)["bbox"][3].asFloat();
         int label = (*iterator)["category_id"].asInt();
         int id = (*iterator)["image_id"].asInt();
         char buffer[13];
@@ -147,11 +147,11 @@ void COCOMetaDataReader::read_all(const std::string &path) {
         auto it = _map_img_sizes.find(file_name);
         ImgSizes image_size = it->second;        
 
-        //Normalizing the co-ordinates
-        box.x/=image_size[0].w;
-        box.y/=image_size[0].h;
-        box.w/=image_size[0].w;
-        box.h/=image_size[0].h;
+        //Normalizing the co-ordinates & convert to "ltrb" format
+        box.l = box_x/ image_size[0].w;
+        box.t = box_y/ image_size[0].h;
+        box.r = (box_x + box_w) / image_size[0].w;
+        box.b = (box_y + box_h) / image_size[0].h;
         
         bb_coords.push_back(box);
         bb_labels.push_back(label);

--- a/rocAL/rocAL/source/coco_meta_data_reader.cpp
+++ b/rocAL/rocAL/source/coco_meta_data_reader.cpp
@@ -81,18 +81,15 @@ void COCOMetaDataReader::print_map_contents()
     BoundingBoxLabels bb_labels;
     ImgSizes img_sizes;
 
-    std::cerr << "\nMap contents: \n";
+    std::cout << "\nBBox Annotations List: \n";
     for (auto& elem : _map_content) {
-        std::cerr << "Name :\t " << elem.first;
+        std::cout << "\nName :\t " << elem.first;
         bb_coords = elem.second->get_bb_cords() ;
         bb_labels = elem.second->get_bb_labels();
         img_sizes = elem.second->get_img_sizes();
-
-        std::cerr << "\nsize of the element  : "<< bb_coords.size() << std::endl;
-        std::cerr << "\nImage original width::\t<<    : "<<img_sizes[0].w<< "\nImage original height::\t<<    : "<<img_sizes[0].h;
+        std::cout << "<wxh, num of bboxes>: "<< img_sizes[0].w << " X " << img_sizes[0].h << " , "  << bb_coords.size() << std::endl;
         for(unsigned int i = 0; i < bb_coords.size(); i++){
-            std::cerr << " x : " << bb_coords[i].x << " y: :" << bb_coords[i].y << " width : " << bb_coords[i].w << " height: :" << bb_coords[i].h << std::endl;
-            std::cerr  << "Label Id : " << bb_labels[i] << std::endl;
+            std::cout << " x : " << bb_coords[i].x << " y: :" << bb_coords[i].y << " width : " << bb_coords[i].w << " height: :" << bb_coords[i].h << "Label Id : " << bb_labels[i] << std::endl;
         }
     }
 }

--- a/rocAL/rocAL/source/coco_meta_data_reader.cpp
+++ b/rocAL/rocAL/source/coco_meta_data_reader.cpp
@@ -117,7 +117,7 @@ void COCOMetaDataReader::read_all(const std::string &path) {
 
     BoundingBoxCord box;
     ImgSize img_size;
-    float box_x, box_y, box_w, box_h;
+    
     for (auto iterator = image.begin(); iterator != image.end(); iterator++)
     {
         // std::map<int, int,int> id_img_sizes;
@@ -133,10 +133,10 @@ void COCOMetaDataReader::read_all(const std::string &path) {
     
     for (auto iterator = annotation.begin(); iterator != annotation.end(); iterator++)
     {
-        box_x = (*iterator)["bbox"][0].asFloat();
-        box_y = (*iterator)["bbox"][1].asFloat();
-        box_w = (*iterator)["bbox"][2].asFloat();
-        box_h = (*iterator)["bbox"][3].asFloat();
+        float box_x = (*iterator)["bbox"][0].asFloat();
+        float box_y = (*iterator)["bbox"][1].asFloat();
+        float box_w = (*iterator)["bbox"][2].asFloat();
+        float box_h = (*iterator)["bbox"][3].asFloat();
         int label = (*iterator)["category_id"].asInt();
         int id = (*iterator)["image_id"].asInt();
         char buffer[13];

--- a/rocAL/rocAL/source/coco_meta_data_reader.cpp
+++ b/rocAL/rocAL/source/coco_meta_data_reader.cpp
@@ -147,6 +147,12 @@ void COCOMetaDataReader::read_all(const std::string &path) {
         auto it = _map_img_sizes.find(file_name);
         ImgSizes image_size = it->second;        
 
+        //Normalizing the co-ordinates
+        box.x/=image_size[0].w;
+        box.y/=image_size[0].h;
+        box.w/=image_size[0].w;
+        box.h/=image_size[0].h;
+        
         bb_coords.push_back(box);
         bb_labels.push_back(label);
         add(file_name, bb_coords, bb_labels,image_size);

--- a/rocAL/rocAL/source/fused_crop_decoder.cpp
+++ b/rocAL/rocAL/source/fused_crop_decoder.cpp
@@ -86,10 +86,10 @@ Decoder::Status FusedCropTJDecoder::decode(unsigned char *input_buffer, size_t i
     unsigned int crop_width, crop_height, x1, y1, x1_diff, crop_width_diff;
     if(_bbox_coord.size() != 0)
     {
-        x1 = _bbox_coord[0];
-        y1 = _bbox_coord[1];
-        crop_width = _bbox_coord[2];
-        crop_height = _bbox_coord[3];
+        x1 = _bbox_coord[0] * original_image_width;
+        y1 = _bbox_coord[1] * original_image_height;
+        crop_width = (_bbox_coord[2]) * original_image_width;
+        crop_height = (_bbox_coord[3]) * original_image_height;
     }
     else
     {

--- a/rocAL/rocAL/source/fused_crop_decoder.cpp
+++ b/rocAL/rocAL/source/fused_crop_decoder.cpp
@@ -137,6 +137,7 @@ Decoder::Status FusedCropTJDecoder::decode(unsigned char *input_buffer, size_t i
         }
     }
     
+   // std::cout<<"Fused Crop Decoder <x,y, w, h>: " << x1 << " " << y1 << " " << crop_width << " " << crop_height << std::endl;
     //TODO : Turbo Jpeg supports multiple color packing and color formats, add more as an option to the API TJPF_RGB, TJPF_BGR, TJPF_RGBX, TJPF_BGRX, TJPF_RGBA, TJPF_GRAY, TJPF_CMYK , ...
     if( tjDecompress2_partial(m_jpegDecompressor,
                       input_buffer,
@@ -159,12 +160,17 @@ Decoder::Status FusedCropTJDecoder::decode(unsigned char *input_buffer, size_t i
     unsigned int elements_in_row = max_decoded_width * planes;
     unsigned int elements_in_crop_row = crop_width * planes;
     unsigned int remainingElements =  elements_in_row - elements_in_crop_row;
+    unsigned int xoffs = (x1-x1_diff) * planes;   // in case x1 gets adjusted by tjpeg decoder
 
+#if 0
     if(_bbox_coord.size() != 0)
     {
         elements_in_crop_row = crop_width_diff * planes;
         _bbox_coord[0] = x1_diff;
-        _bbox_coord[2] = crop_width_diff;    }
+        _bbox_coord[2] = crop_width_diff;
+    }
+    std::cout<<"Fused Crop Decoder after crop<x,y, w, h>: " << x1_diff << " " << y1 << " " << crop_width_diff << " " << crop_height << std::endl;
+#endif
 
     src_ptr_temp = output_buffer + (y1 *  elements_in_row);
     dst_ptr_temp = output_buffer;
@@ -172,21 +178,23 @@ Decoder::Status FusedCropTJDecoder::decode(unsigned char *input_buffer, size_t i
     unsigned int i = 0;
     for (; i < crop_height; i++)
     {
-        memcpy(dst_ptr_temp, src_ptr_temp, elements_in_crop_row * sizeof(unsigned char));
+        memcpy(dst_ptr_temp, src_ptr_temp + xoffs, elements_in_crop_row * sizeof(unsigned char));
         memset(dst_ptr_temp + elements_in_crop_row, 0, remainingElements * sizeof(unsigned char));
         src_ptr_temp +=  elements_in_row;
         dst_ptr_temp +=  elements_in_row;
     }
+#if 0 // do we need this?    
     for (; i < max_decoded_height; i++)
     {
         memset(dst_ptr_temp, 0,  elements_in_row * sizeof(unsigned char));
         dst_ptr_temp +=  elements_in_row;
     }
+#endif    
 
-    if(_bbox_coord.size() != 0)
-        actual_decoded_width = crop_width_diff;
-    else
-        actual_decoded_width = crop_width;
+    //if(_bbox_coord.size() != 0)
+    //    actual_decoded_width = crop_width_diff;
+    //else
+    actual_decoded_width = crop_width;
     actual_decoded_height = crop_height;
 
     return Status::OK;

--- a/rocAL/rocAL/source/fused_crop_decoder.cpp
+++ b/rocAL/rocAL/source/fused_crop_decoder.cpp
@@ -164,16 +164,6 @@ Decoder::Status FusedCropTJDecoder::decode(unsigned char *input_buffer, size_t i
     unsigned int remainingElements =  elements_in_row - elements_in_crop_row;
     unsigned int xoffs = (x1-x1_diff) * planes;   // in case x1 gets adjusted by tjpeg decoder
 
-#if 0
-    if(_bbox_coord.size() != 0)
-    {
-        elements_in_crop_row = crop_width_diff * planes;
-        _bbox_coord[0] = x1_diff;
-        _bbox_coord[2] = crop_width_diff;
-    }
-    std::cout<<"Fused Crop Decoder after crop<x,y, w, h>: " << x1_diff << " " << y1 << " " << crop_width_diff << " " << crop_height << std::endl;
-#endif
-
     src_ptr_temp = output_buffer + (y1 *  elements_in_row);
     dst_ptr_temp = output_buffer;
 
@@ -185,14 +175,7 @@ Decoder::Status FusedCropTJDecoder::decode(unsigned char *input_buffer, size_t i
         src_ptr_temp +=  elements_in_row;
         dst_ptr_temp +=  elements_in_row;
     }
-#if 0 // do we need this?    
-    for (; i < max_decoded_height; i++)
-    {
-        memset(dst_ptr_temp, 0,  elements_in_row * sizeof(unsigned char));
-        dst_ptr_temp +=  elements_in_row;
-    }
-#endif    
-
+    
     //if(_bbox_coord.size() != 0)
     //    actual_decoded_width = crop_width_diff;
     //else

--- a/rocAL/rocAL/source/fused_crop_decoder.cpp
+++ b/rocAL/rocAL/source/fused_crop_decoder.cpp
@@ -86,6 +86,8 @@ Decoder::Status FusedCropTJDecoder::decode(unsigned char *input_buffer, size_t i
     unsigned int crop_width, crop_height, x1, y1, x1_diff, crop_width_diff;
     if(_bbox_coord.size() != 0)
     {
+        // Random bbox crop returns normalized crop cordinates
+        // hence bringing it back to absolute cordinates 
         x1 = _bbox_coord[0] * original_image_width;
         y1 = _bbox_coord[1] * original_image_height;
         crop_width = (_bbox_coord[2]) * original_image_width;

--- a/rocAL/rocAL/source/image_read_and_decode.cpp
+++ b/rocAL/rocAL/source/image_read_and_decode.cpp
@@ -274,12 +274,14 @@ ImageReadAndDecode::load(unsigned char* buff,
         }
         for (size_t i = 0; i < _batch_size; i++) {
             names[i] = _image_names[i];
+#if 0   // decoder shouldn't change the crop coordinates
             if(_randombboxcrop_meta_data_reader)
             {
                 _CropCord = _randombboxcrop_meta_data_reader->get_crop_cord(_image_names[i]);
                 _CropCord->crop_x = _decoder[i]->get_bbox_coords()[0];
-		        _CropCord->crop_width = _decoder[i]->get_bbox_coords()[2];
+		            _CropCord->crop_width = _decoder[i]->get_bbox_coords()[2];
             }
+#endif            
             roi_width[i] = _actual_decoded_width[i];
             roi_height[i] = _actual_decoded_height[i];
             actual_width[i] = _original_width[i];

--- a/rocAL/rocAL/source/image_read_and_decode.cpp
+++ b/rocAL/rocAL/source/image_read_and_decode.cpp
@@ -274,16 +274,7 @@ ImageReadAndDecode::load(unsigned char* buff,
         }
         for (size_t i = 0; i < _batch_size; i++) {
             names[i] = _image_names[i];
-#if 0   // decoder shouldn't change the crop coordinates
-            if(_randombboxcrop_meta_data_reader)
-            {
-                _CropCord = _randombboxcrop_meta_data_reader->get_crop_cord(_image_names[i]);
-                _CropCord->crop_left = _decoder[i]->get_bbox_coords()[0];
-		        _CropCord->crop_top = _decoder[i]->get_bbox_coords()[1];
-                _CropCord->crop_right = _decoder[i]->get_bbox_coords()[2];
-		        _CropCord->crop_bottom = _decoder[i]->get_bbox_coords()[3];
-            }
-#endif            
+           
             roi_width[i] = _actual_decoded_width[i];
             roi_height[i] = _actual_decoded_height[i];
             actual_width[i] = _original_width[i];

--- a/rocAL/rocAL/source/image_read_and_decode.cpp
+++ b/rocAL/rocAL/source/image_read_and_decode.cpp
@@ -192,10 +192,10 @@ ImageReadAndDecode::load(unsigned char* buff,
             {
                 _CropCord = _randombboxcrop_meta_data_reader->get_crop_cord(_image_names[file_counter]);
                 std::vector<float> coords_buf(4);
-                coords_buf[0] = _CropCord->crop_x;
-                coords_buf[1] = _CropCord->crop_y;
-                coords_buf[2] = _CropCord->crop_width;
-                coords_buf[3] = _CropCord->crop_height;
+                coords_buf[0] = _CropCord->crop_left ;
+                coords_buf[1] = _CropCord->crop_top;
+                coords_buf[2] = _CropCord->crop_right- _CropCord->crop_left ;
+                coords_buf[3] = _CropCord->crop_bottom- _CropCord->crop_top;
                 _bbox_coords.push_back(coords_buf);
                 coords_buf.clear();
             }
@@ -278,8 +278,10 @@ ImageReadAndDecode::load(unsigned char* buff,
             if(_randombboxcrop_meta_data_reader)
             {
                 _CropCord = _randombboxcrop_meta_data_reader->get_crop_cord(_image_names[i]);
-                _CropCord->crop_x = _decoder[i]->get_bbox_coords()[0];
-		            _CropCord->crop_width = _decoder[i]->get_bbox_coords()[2];
+                _CropCord->crop_left = _decoder[i]->get_bbox_coords()[0];
+		        _CropCord->crop_top = _decoder[i]->get_bbox_coords()[1];
+                _CropCord->crop_right = _decoder[i]->get_bbox_coords()[2];
+		        _CropCord->crop_bottom = _decoder[i]->get_bbox_coords()[3];
             }
 #endif            
             roi_width[i] = _actual_decoded_width[i];

--- a/rocAL/rocAL/source/master_graph.cpp
+++ b/rocAL/rocAL/source/master_graph.cpp
@@ -882,12 +882,12 @@ MetaDataBatch * MasterGraph::create_label_reader(const char *source_path, MetaDa
 }
 
 
-void MasterGraph::create_randombboxcrop_reader(RandomBBoxCrop_MetaDataReaderType reader_type, RandomBBoxCrop_MetaDataType label_type, bool all_boxes_overlap, bool no_crop, FloatParam* aspect_ratio, bool has_shape, int crop_width, int crop_height, int num_attempts, FloatParam* scaling, int total_num_attempts)
+void MasterGraph::create_randombboxcrop_reader(RandomBBoxCrop_MetaDataReaderType reader_type, RandomBBoxCrop_MetaDataType label_type, bool all_boxes_overlap, bool no_crop, FloatParam* aspect_ratio, bool has_shape, int crop_width, int crop_height, int num_attempts, FloatParam* scaling, int total_num_attempts, int64_t seed)
 {
     if( _randombboxcrop_meta_data_reader)
         THROW("A metadata reader has already been created")
     _is_random_bbox_crop = true;
-    RandomBBoxCrop_MetaDataConfig config(label_type, reader_type, all_boxes_overlap, no_crop, aspect_ratio, has_shape, crop_width, crop_height, num_attempts, scaling, total_num_attempts);
+    RandomBBoxCrop_MetaDataConfig config(label_type, reader_type, all_boxes_overlap, no_crop, aspect_ratio, has_shape, crop_width, crop_height, num_attempts, scaling, total_num_attempts, seed);
     _randombboxcrop_meta_data_reader = create_meta_data_reader(config);
     _randombboxcrop_meta_data_reader->set_meta_data(_meta_data_reader);
     _randombboxcrop_meta_data_reader->read_all();

--- a/rocAL/rocAL/source/meta_node_crop.cpp
+++ b/rocAL/rocAL/source/meta_node_crop.cpp
@@ -57,37 +57,37 @@ void CropMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         BoundingBoxCord temp_box;
         BoundingBoxLabels bb_labels;
         BoundingBoxCord crop_box;
-        crop_box.x = _x1_val[i];
-        crop_box.y = _y1_val[i];
-        crop_box.w = _crop_width_val[i];
-        crop_box.h = _crop_height_val[i];
+        crop_box.l = _x1_val[i];
+        crop_box.t = _y1_val[i];
+        crop_box.r = _x1_val[i] + _crop_width_val[i];
+        crop_box.b = _y1_val[i] + _crop_height_val[i];
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
-            box.x = coords_buf[m++];
-            box.y = coords_buf[m++];
-            box.w = coords_buf[m++];
-            box.h = coords_buf[m++];
+            box.l = coords_buf[m++];
+            box.t = coords_buf[m++];
+            box.r = coords_buf[m++];
+            box.b = coords_buf[m++];
             if (BBoxIntersectionOverUnion(box, crop_box) >= _iou_threshold)
             {
-                float xA = std::max(crop_box.x, box.x);
-                float yA = std::max(crop_box.y, box.y);
-                float xB = std::min(crop_box.x + crop_box.w, box.x + box.w);
-                float yB = std::min(crop_box.y + crop_box.h, box.y + box.h);
-                box.x = xA - _x1_val[i];
-                box.y = yA - _y1_val[i];
-                box.w = xB - xA;
-                box.h = yB - yA;
+                float xA = std::max(crop_box.l, box.l);
+                float yA = std::max(crop_box.t, box.t);
+                float xB = std::min(crop_box.r, box.r);
+                float yB = std::min(crop_box.b, box.b);
+                box.l = (xA - crop_box.l) / (crop_box.r - crop_box.l);
+                box.t = (yA - crop_box.t) / (crop_box.b - crop_box.t);
+                box.r = (xB - crop_box.l) / (crop_box.r - crop_box.l);
+                box.b = (yB - crop_box.t) / (crop_box.b - crop_box.t);
                 bb_coords.push_back(box);
                 bb_labels.push_back(labels_buf[j]);
             }
         }
         if(bb_coords.size() == 0)
         {
-            temp_box.x = 0;
-            temp_box.y = 0;
-            temp_box.w =  crop_box.w - 1;
-	        temp_box.h =  crop_box.h - 1;
+            temp_box.l = 0;
+            temp_box.t = 0;
+            temp_box.r = 1;
+	        temp_box.b = 1;
             bb_coords.push_back(temp_box);
             bb_labels.push_back(0);
         }

--- a/rocAL/rocAL/source/meta_node_crop_mirror_normalize.cpp
+++ b/rocAL/rocAL/source/meta_node_crop_mirror_normalize.cpp
@@ -79,7 +79,6 @@ void CropMirrorNormalizeMetaNode::update_parameters(MetaDataBatch* input_meta_da
             box.r = coords_buf[m++];
             box.b = coords_buf[m++];
             // std::cout<<"\nIn BEFORE CMN: Box Co-ordinates lxtxrxb::\t"<<box.l<<"x\t"<<box.t<<"x\t"<<box.r<<"x\t"<<box.b<<"x\t"<<std::endl;
-
             if (BBoxIntersectionOverUnion(box, crop_box) >= _iou_threshold)
             {
                 float xA = std::max(crop_box.l, box.l);
@@ -96,9 +95,8 @@ void CropMirrorNormalizeMetaNode::update_parameters(MetaDataBatch* input_meta_da
                 {
 
                     float l = 1 - box.r;
-                    float r = 1 - box.l;
+                    box.r = 1 - box.l;
                     box.l = l;
-                    box.r = r;
                 }
                 // std::cout<<"\n AFTER MIRROR IN CMN: Box Co-ordinates lxtxrxb::\t"<<box.l<<"x\t"<<box.t<<"x\t"<<box.r<<"x\t"<<box.b<<"x\t"<<std::endl;
 

--- a/rocAL/rocAL/source/meta_node_crop_mirror_normalize.cpp
+++ b/rocAL/rocAL/source/meta_node_crop_mirror_normalize.cpp
@@ -65,33 +65,43 @@ void CropMirrorNormalizeMetaNode::update_parameters(MetaDataBatch* input_meta_da
         BoundingBoxCord temp_box;
         BoundingBoxLabels bb_labels;
         BoundingBoxCord crop_box;
-        crop_box.x = _x1_val[i]/_src_width_val[i];
-        crop_box.y = _y1_val[i]/_src_height_val[i];
-        crop_box.w = _width_val[i]/_src_width_val[i];
-        crop_box.h = _height_val[i]/_src_height_val[i];
+        crop_box.l = (_x1_val[i]) / _src_width_val[i];
+        crop_box.t = (_y1_val[i]) / _src_height_val[i];
+        crop_box.r = (_x1_val[i] + _width_val[i]) / _src_width_val[i];
+        crop_box.b = (_y1_val[i] + _height_val[i]) / _src_height_val[i];
+        // std::cout<<"CROP Co-ordinates in CMN: lxtxrxb::\t"<<crop_box.l<<"x"<<crop_box.t<<"x"<<crop_box.r<<"x"<<crop_box.b<<"x";
         
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
-            box.x = coords_buf[m++];
-            box.y = coords_buf[m++];
-            box.w = coords_buf[m++];
-            box.h = coords_buf[m++];
+            box.l = coords_buf[m++];
+            box.t = coords_buf[m++];
+            box.r = coords_buf[m++];
+            box.b = coords_buf[m++];
+            // std::cout<<"\nIn BEFORE CMN: Box Co-ordinates lxtxrxb::\t"<<box.l<<"x\t"<<box.t<<"x\t"<<box.r<<"x\t"<<box.b<<"x\t"<<std::endl;
+
             if (BBoxIntersectionOverUnion(box, crop_box) >= _iou_threshold)
             {
-                float xA = std::max(crop_box.x, box.x);
-                float yA = std::max(crop_box.y, box.y);
-                float xB = std::min(crop_box.x + crop_box.w, box.x + box.w);
-                float yB = std::min(crop_box.y + crop_box.h, box.y + box.h);
-                box.x = xA - _x1_val[i];
-                box.y = yA - _y1_val[i];
-                box.w = xB - xA;
-                box.h = yB - yA;
+                float xA = std::max(crop_box.l, box.l);
+                float yA = std::max(crop_box.t, box.t);
+                float xB = std::min(crop_box.r, box.r);
+                float yB = std::min(crop_box.b, box.b);
+                box.l = (xA - crop_box.l) / (crop_box.r - crop_box.l);
+                box.t = (yA - crop_box.t) / (crop_box.b - crop_box.t);
+                box.r = (xB - crop_box.l) / (crop_box.r - crop_box.l);
+                box.b = (yB - crop_box.t) / (crop_box.b - crop_box.t);
+                // std::cout<<"\n AFTER IN CMN: Box Co-ordinates lxtxrxb::\t"<<box.l<<"x\t"<<box.t<<"x\t"<<box.r<<"x\t"<<box.b<<"x\t"<<std::endl;
+
                 if (_mirror_val[i] == 1)
                 {
-                    float centre_x = 0.5;
-                    box.x += ((centre_x - box.x) * 2) - box.w;
+
+                    float l = 1 - box.r;
+                    float r = 1 - box.l;
+                    box.l = l;
+                    box.r = r;
                 }
+                // std::cout<<"\n AFTER MIRROR IN CMN: Box Co-ordinates lxtxrxb::\t"<<box.l<<"x\t"<<box.t<<"x\t"<<box.r<<"x\t"<<box.b<<"x\t"<<std::endl;
+
                 bb_coords.push_back(box);
                 bb_labels.push_back(labels_buf[j]);
             }
@@ -99,10 +109,10 @@ void CropMirrorNormalizeMetaNode::update_parameters(MetaDataBatch* input_meta_da
         if(bb_coords.size() == 0)
         {
 	        //std::cout << "Crop mirror Normalize - Zero Bounding boxes" << std::endl;
-            temp_box.x = 0;
-            temp_box.y = 0;
-	        temp_box.w =  crop_box.w - 1;
-	        temp_box.h =  crop_box.h - 1;
+            temp_box.l = 0;
+            temp_box.t = 0;
+	        temp_box.r = 1;
+	        temp_box.b = 1;
             bb_coords.push_back(temp_box);
             bb_labels.push_back(0);
         }

--- a/rocAL/rocAL/source/meta_node_crop_mirror_normalize.cpp
+++ b/rocAL/rocAL/source/meta_node_crop_mirror_normalize.cpp
@@ -62,7 +62,7 @@ void CropMirrorNormalizeMetaNode::update_parameters(MetaDataBatch* input_meta_da
         memcpy(labels_buf, input_meta_data->get_bb_labels_batch()[i].data(),  sizeof(int)*bb_count);
         memcpy(coords_buf, input_meta_data->get_bb_cords_batch()[i].data(), input_meta_data->get_bb_cords_batch()[i].size() * sizeof(BoundingBoxCord));
         BoundingBoxCords bb_coords;
-        BoundingBoxCord temp_box;
+        BoundingBoxCord temp_box = {0, 0, 1, 1};
         BoundingBoxLabels bb_labels;
         BoundingBoxCord crop_box;
         crop_box.l = (_x1_val[i]) / _src_width_val[i];
@@ -89,8 +89,6 @@ void CropMirrorNormalizeMetaNode::update_parameters(MetaDataBatch* input_meta_da
                 box.t = (yA - crop_box.t) / (crop_box.b - crop_box.t);
                 box.r = (xB - crop_box.l) / (crop_box.r - crop_box.l);
                 box.b = (yB - crop_box.t) / (crop_box.b - crop_box.t);
-                // std::cout<<"\n AFTER IN CMN: Box Co-ordinates lxtxrxb::\t"<<box.l<<"x\t"<<box.t<<"x\t"<<box.r<<"x\t"<<box.b<<"x\t"<<std::endl;
-
                 if (_mirror_val[i] == 1)
                 {
 
@@ -98,19 +96,14 @@ void CropMirrorNormalizeMetaNode::update_parameters(MetaDataBatch* input_meta_da
                     box.r = 1 - box.l;
                     box.l = l;
                 }
-                // std::cout<<"\n AFTER MIRROR IN CMN: Box Co-ordinates lxtxrxb::\t"<<box.l<<"x\t"<<box.t<<"x\t"<<box.r<<"x\t"<<box.b<<"x\t"<<std::endl;
-
                 bb_coords.push_back(box);
                 bb_labels.push_back(labels_buf[j]);
             }
         }
+        // the following shouldn't happen since all crops should atleast have one bbox
         if(bb_coords.size() == 0)
         {
-	        //std::cout << "Crop mirror Normalize - Zero Bounding boxes" << std::endl;
-            temp_box.l = 0;
-            temp_box.t = 0;
-	        temp_box.r = 1;
-	        temp_box.b = 1;
+            std::cerr <<"Crop mirror Normalize - Zero Bounding boxes" << std::endl;
             bb_coords.push_back(temp_box);
             bb_labels.push_back(0);
         }

--- a/rocAL/rocAL/source/meta_node_crop_resize.cpp
+++ b/rocAL/rocAL/source/meta_node_crop_resize.cpp
@@ -61,43 +61,45 @@ void CropResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         BoundingBoxCord crop_box;
         _crop_w = _x2_val[i] - _x1_val[i];
         _crop_h = _y2_val[i] - _y1_val[i];
-        crop_box.x = _x1_val[i];
-        crop_box.y = _y1_val[i];
-        crop_box.w = _crop_w;
-        crop_box.h = _crop_h;
+        //TBD
+        crop_box.l = _x1_val[i];
+        crop_box.t = _y1_val[i];
+        crop_box.r = _crop_w;
+        crop_box.b = _crop_h;
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
-            box.x = coords_buf[m++];
-            box.y = coords_buf[m++];
-            box.w = coords_buf[m++];
-            box.h = coords_buf[m++];
-            if (BBoxIntersectionOverUnion(box, crop_box) >= _iou_threshold)
-            {
-                float xA = std::max(crop_box.x, box.x);
-                float yA = std::max(crop_box.y, box.y);
-                float xB = std::min(crop_box.x + crop_box.w, box.x + box.w);
-                float yB = std::min(crop_box.y + crop_box.h, box.y + box.h);
-                box.x = xA - _x1_val[i];
-                box.y = yA - _y1_val[i];
-                box.w = xB - xA;
-                box.h = yB - yA;
-                _dst_to_src_width_ratio = _dst_width / float(_crop_w);
-                _dst_to_src_height_ratio = _dst_height / float(_crop_h);
-                box.x *= _dst_to_src_width_ratio;
-                box.y *= _dst_to_src_height_ratio;
-                box.w *= _dst_to_src_width_ratio;
-                box.h *= _dst_to_src_height_ratio;
-                bb_coords.push_back(box);
-                bb_labels.push_back(labels_buf[j]);
-            }
+            box.l = coords_buf[m++];
+            box.t = coords_buf[m++];
+            box.r = coords_buf[m++];
+            box.b = coords_buf[m++];
+            //TBD
+            // if (BBoxIntersectionOverUnion(box, crop_box) >= _iou_threshold)
+            // {
+            //     float xA = std::max(crop_box.x, box.x);
+            //     float yA = std::max(crop_box.y, box.y);
+            //     float xB = std::min(crop_box.x + crop_box.w, box.x + box.w);
+            //     float yB = std::min(crop_box.y + crop_box.h, box.y + box.h);
+            //     box.x = xA - _x1_val[i];
+            //     box.y = yA - _y1_val[i];
+            //     box.w = xB - xA;
+            //     box.h = yB - yA;
+            //     _dst_to_src_width_ratio = _dst_width / float(_crop_w);
+            //     _dst_to_src_height_ratio = _dst_height / float(_crop_h);
+            //     box.x *= _dst_to_src_width_ratio;
+            //     box.y *= _dst_to_src_height_ratio;
+            //     box.w *= _dst_to_src_width_ratio;
+            //     box.h *= _dst_to_src_height_ratio;
+            //     bb_coords.push_back(box);
+            //     bb_labels.push_back(labels_buf[j]);
+            // }
         }
         if(bb_coords.size() == 0)
         {
-            temp_box.x = 0;
-            temp_box.y = 0;
-            temp_box.w =  crop_box.w - 1;
-	        temp_box.h =  crop_box.h - 1;
+            temp_box.l = 0;
+            temp_box.t = 0;
+            temp_box.r = 1;
+	        temp_box.b = 1;
             bb_coords.push_back(temp_box);
             bb_labels.push_back(0);
         }

--- a/rocAL/rocAL/source/meta_node_crop_resize.cpp
+++ b/rocAL/rocAL/source/meta_node_crop_resize.cpp
@@ -64,8 +64,8 @@ void CropResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         //TBD
         crop_box.l = _x1_val[i];
         crop_box.t = _y1_val[i];
-        crop_box.r = _crop_w;
-        crop_box.b = _crop_h;
+        crop_box.r = _x1_val[i]+_crop_w;
+        crop_box.b = _y1_val[i]+_crop_h;
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
@@ -73,26 +73,21 @@ void CropResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
             box.t = coords_buf[m++];
             box.r = coords_buf[m++];
             box.b = coords_buf[m++];
-            //TBD
-            // if (BBoxIntersectionOverUnion(box, crop_box) >= _iou_threshold)
-            // {
-            //     float xA = std::max(crop_box.x, box.x);
-            //     float yA = std::max(crop_box.y, box.y);
-            //     float xB = std::min(crop_box.x + crop_box.w, box.x + box.w);
-            //     float yB = std::min(crop_box.y + crop_box.h, box.y + box.h);
-            //     box.x = xA - _x1_val[i];
-            //     box.y = yA - _y1_val[i];
-            //     box.w = xB - xA;
-            //     box.h = yB - yA;
-            //     _dst_to_src_width_ratio = _dst_width / float(_crop_w);
-            //     _dst_to_src_height_ratio = _dst_height / float(_crop_h);
-            //     box.x *= _dst_to_src_width_ratio;
-            //     box.y *= _dst_to_src_height_ratio;
-            //     box.w *= _dst_to_src_width_ratio;
-            //     box.h *= _dst_to_src_height_ratio;
-            //     bb_coords.push_back(box);
-            //     bb_labels.push_back(labels_buf[j]);
-            // }
+            
+            if (BBoxIntersectionOverUnion(box, crop_box) >= _iou_threshold)
+            {
+                float xA = std::max(crop_box.l, box.l);
+                float yA = std::max(crop_box.t, box.t);
+                float xB = std::min(crop_box.r, box.r);
+                float yB = std::min(crop_box.b, box.b);
+                box.l = (xA - crop_box.l) / (crop_box.r - crop_box.l);
+                box.t = (yA - crop_box.t) / (crop_box.b - crop_box.t);
+                box.r = (xB - crop_box.l) / (crop_box.r - crop_box.l);
+                box.b = (yB - crop_box.t) / (crop_box.b - crop_box.t);
+                
+                bb_coords.push_back(box);
+                bb_labels.push_back(labels_buf[j]);
+            }
         }
         if(bb_coords.size() == 0)
         {

--- a/rocAL/rocAL/source/meta_node_crop_resize.cpp
+++ b/rocAL/rocAL/source/meta_node_crop_resize.cpp
@@ -47,6 +47,7 @@ void CropResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
     vxCopyArrayRange((vx_array)_y1, 0, _batch_size, sizeof(uint),_y1_val.data(), VX_READ_ONLY, VX_MEMORY_TYPE_HOST);
     vxCopyArrayRange((vx_array)_x2, 0, _batch_size, sizeof(uint),_x2_val.data(), VX_READ_ONLY, VX_MEMORY_TYPE_HOST);
     vxCopyArrayRange((vx_array)_y2, 0, _batch_size, sizeof(uint),_y2_val.data(), VX_READ_ONLY, VX_MEMORY_TYPE_HOST);
+    BoundingBoxCord temp_box = {0, 0, 1, 1};
 
     for(int i = 0; i < _batch_size; i++)
     {
@@ -56,7 +57,6 @@ void CropResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         memcpy(labels_buf, input_meta_data->get_bb_labels_batch()[i].data(),  sizeof(int)*bb_count);
         memcpy(coords_buf, input_meta_data->get_bb_cords_batch()[i].data(), input_meta_data->get_bb_cords_batch()[i].size() * sizeof(BoundingBoxCord));
         BoundingBoxCords bb_coords;
-        BoundingBoxCord temp_box;
         BoundingBoxLabels bb_labels;
         BoundingBoxCord crop_box;
         _crop_w = _x2_val[i] - _x1_val[i];
@@ -91,10 +91,6 @@ void CropResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         }
         if(bb_coords.size() == 0)
         {
-            temp_box.l = 0;
-            temp_box.t = 0;
-            temp_box.r = 1;
-	        temp_box.b = 1;
             bb_coords.push_back(temp_box);
             bb_labels.push_back(0);
         }

--- a/rocAL/rocAL/source/meta_node_flip.cpp
+++ b/rocAL/rocAL/source/meta_node_flip.cpp
@@ -49,7 +49,7 @@ void FlipMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         memcpy(coords_buf, input_meta_data->get_bb_cords_batch()[i].data(), input_meta_data->get_bb_cords_batch()[i].size() * sizeof(BoundingBoxCord));
         BoundingBoxCords bb_coords;
         BoundingBoxLabels bb_labels;
-        //YTD
+        
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
@@ -69,8 +69,8 @@ void FlipMetaNode::update_parameters(MetaDataBatch* input_meta_data)
             {
                 float t = 1 - box.b;
                 float b = 1 - box.t;
-                box.t = l;
-                box.b = r;
+                box.t = t;
+                box.b = b;
             }
             
             bb_coords.push_back(box);
@@ -79,7 +79,6 @@ void FlipMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         if(bb_coords.size() == 0)
         {
             BoundingBoxCord temp_box;
-            //YTD
             temp_box.l = temp_box.t = 0;
             temp_box.r = temp_box.b = 1;
             bb_coords.push_back(temp_box);

--- a/rocAL/rocAL/source/meta_node_flip.cpp
+++ b/rocAL/rocAL/source/meta_node_flip.cpp
@@ -49,31 +49,35 @@ void FlipMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         memcpy(coords_buf, input_meta_data->get_bb_cords_batch()[i].data(), input_meta_data->get_bb_cords_batch()[i].size() * sizeof(BoundingBoxCord));
         BoundingBoxCords bb_coords;
         BoundingBoxLabels bb_labels;
+        //YTD
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
-            box.x = coords_buf[m++];
-            box.y = coords_buf[m++];
-            box.w = coords_buf[m++];
-            box.h = coords_buf[m++];
-            if(_flip_axis_val[i] == 0)
-            {
-                float centre_x = _src_width_val[i] / 2;
-                box.x += ((centre_x - box.x) * 2) - box.w;
-            }
-            else if(_flip_axis_val[i] == 1)
-            {
-                float centre_y = _src_height_val[i] / 2;
-                box.y += ((centre_y - box.y) * 2) - box.h;
+            box.l = coords_buf[m++];
+            box.t = coords_buf[m++];
+            box.r = coords_buf[m++];
+            box.b = coords_buf[m++];
+            //YTD: The commented code has to be re-written--
+            // if(_flip_axis_val[i] == 0)
+            // {
+            //     float centre_x = _src_width_val[i] / 2;
+            //     box.x += ((centre_x - box.x) * 2) - box.w;
+            // }
+            // else if(_flip_axis_val[i] == 1)
+            // {
+            //     float centre_y = _src_height_val[i] / 2;
+            //     box.y += ((centre_y - box.y) * 2) - box.h;
 
-            }
+            // }
+            //YTD
             bb_coords.push_back(box);
             bb_labels.push_back(labels_buf[j]);
         }
         if(bb_coords.size() == 0)
         {
             BoundingBoxCord temp_box;
-            temp_box.x = temp_box.y = temp_box.w = temp_box.h = 0;
+            //YTD
+            temp_box.l = temp_box.t = temp_box.r = temp_box.b = 0;
             bb_coords.push_back(temp_box);
             bb_labels.push_back(0);
         }

--- a/rocAL/rocAL/source/meta_node_flip.cpp
+++ b/rocAL/rocAL/source/meta_node_flip.cpp
@@ -61,16 +61,14 @@ void FlipMetaNode::update_parameters(MetaDataBatch* input_meta_data)
             if(_flip_axis_val[i] == 0)
             {
                 float l = 1 - box.r;
-                float r = 1 - box.l;
-                box.l = l;
-                box.r = r;
+                box.r = 1 - box.l;
+                box.l = l;     
             }
             else if(_flip_axis_val[i] == 1)
             {
                 float t = 1 - box.b;
-                float b = 1 - box.t;
+                box.b = 1 - box.t;
                 box.t = t;
-                box.b = b;
             }
             
             bb_coords.push_back(box);

--- a/rocAL/rocAL/source/meta_node_flip.cpp
+++ b/rocAL/rocAL/source/meta_node_flip.cpp
@@ -57,19 +57,22 @@ void FlipMetaNode::update_parameters(MetaDataBatch* input_meta_data)
             box.t = coords_buf[m++];
             box.r = coords_buf[m++];
             box.b = coords_buf[m++];
-            //YTD: The commented code has to be re-written--
-            // if(_flip_axis_val[i] == 0)
-            // {
-            //     float centre_x = _src_width_val[i] / 2;
-            //     box.x += ((centre_x - box.x) * 2) - box.w;
-            // }
-            // else if(_flip_axis_val[i] == 1)
-            // {
-            //     float centre_y = _src_height_val[i] / 2;
-            //     box.y += ((centre_y - box.y) * 2) - box.h;
-
-            // }
-            //YTD
+            
+            if(_flip_axis_val[i] == 0)
+            {
+                float l = 1 - box.r;
+                float r = 1 - box.l;
+                box.l = l;
+                box.r = r;
+            }
+            else if(_flip_axis_val[i] == 1)
+            {
+                float t = 1 - box.b;
+                float b = 1 - box.t;
+                box.t = l;
+                box.b = r;
+            }
+            
             bb_coords.push_back(box);
             bb_labels.push_back(labels_buf[j]);
         }
@@ -77,7 +80,8 @@ void FlipMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         {
             BoundingBoxCord temp_box;
             //YTD
-            temp_box.l = temp_box.t = temp_box.r = temp_box.b = 0;
+            temp_box.l = temp_box.t = 0;
+            temp_box.r = temp_box.b = 1;
             bb_coords.push_back(temp_box);
             bb_labels.push_back(0);
         }

--- a/rocAL/rocAL/source/meta_node_resize.cpp
+++ b/rocAL/rocAL/source/meta_node_resize.cpp
@@ -41,8 +41,6 @@ void ResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
     _dst_height = _node->get_dst_height();
     for(int i = 0; i < _batch_size; i++)
     {
-        _dst_to_src_width_ratio = _dst_width / float(_src_width_val[i]);
-        _dst_to_src_height_ratio = _dst_height / float(_src_height_val[i]);
         auto bb_count = input_meta_data->get_bb_labels_batch()[i].size();
         int labels_buf[bb_count];
         float coords_buf[bb_count*4];
@@ -55,10 +53,10 @@ void ResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
-            box.x = (coords_buf[m++] * _dst_to_src_width_ratio);
-            box.y = (coords_buf[m++] * _dst_to_src_height_ratio);
-            box.w = (coords_buf[m++] * _dst_to_src_width_ratio);
-            box.h = (coords_buf[m++] * _dst_to_src_height_ratio);
+            box.x = (coords_buf[m++] );
+            box.y = (coords_buf[m++] );
+            box.w = (coords_buf[m++] );
+            box.h = (coords_buf[m++] );
             bb_coords.push_back(box);
             bb_labels.push_back(labels_buf[j]);
         }

--- a/rocAL/rocAL/source/meta_node_resize.cpp
+++ b/rocAL/rocAL/source/meta_node_resize.cpp
@@ -28,6 +28,7 @@ void ResizeMetaNode::initialize()
 }
 void ResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
 {
+#if 0  
     initialize();
     if(_batch_size != input_meta_data->size())
     {
@@ -51,7 +52,7 @@ void ResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
-            box.l = (coords_buf[m++] );
+            box.l = (coords_buf[m++]);
             box.t = (coords_buf[m++] );
             box.r = (coords_buf[m++] );
             box.b = (coords_buf[m++] );
@@ -61,4 +62,7 @@ void ResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         input_meta_data->get_bb_cords_batch()[i] = bb_coords;
         input_meta_data->get_bb_labels_batch()[i] = bb_labels;
     }
+#else
+    // nothing to do in normalized coordinates
+#endif    
 }

--- a/rocAL/rocAL/source/meta_node_resize.cpp
+++ b/rocAL/rocAL/source/meta_node_resize.cpp
@@ -48,20 +48,22 @@ void ResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         memcpy(coords_buf, input_meta_data->get_bb_cords_batch()[i].data(), input_meta_data->get_bb_cords_batch()[i].size() * sizeof(BoundingBoxCord));
         BoundingBoxCords bb_coords;
         BoundingBoxCord temp_box;
-        temp_box.x = temp_box.y = temp_box.w = temp_box.h = 0;
+        temp_box.l = temp_box.t= 0;
+        temp_box.r = temp_box.b = 1;
         BoundingBoxLabels bb_labels;
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
-            box.x = (coords_buf[m++] );
-            box.y = (coords_buf[m++] );
-            box.w = (coords_buf[m++] );
-            box.h = (coords_buf[m++] );
+            box.l = (coords_buf[m++] );
+            box.t = (coords_buf[m++] );
+            box.r = (coords_buf[m++] );
+            box.b = (coords_buf[m++] );
             bb_coords.push_back(box);
             bb_labels.push_back(labels_buf[j]);
         }
         if(bb_coords.size() == 0)
         {
+            std::cout<<"Zero BBoxes in Meta Node Resize";
             bb_coords.push_back(temp_box);
             bb_labels.push_back(0);
         }

--- a/rocAL/rocAL/source/meta_node_resize.cpp
+++ b/rocAL/rocAL/source/meta_node_resize.cpp
@@ -47,9 +47,6 @@ void ResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         memcpy(labels_buf, input_meta_data->get_bb_labels_batch()[i].data(),  sizeof(int)*bb_count);
         memcpy(coords_buf, input_meta_data->get_bb_cords_batch()[i].data(), input_meta_data->get_bb_cords_batch()[i].size() * sizeof(BoundingBoxCord));
         BoundingBoxCords bb_coords;
-        BoundingBoxCord temp_box;
-        temp_box.l = temp_box.t= 0;
-        temp_box.r = temp_box.b = 1;
         BoundingBoxLabels bb_labels;
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
@@ -60,12 +57,6 @@ void ResizeMetaNode::update_parameters(MetaDataBatch* input_meta_data)
             box.b = (coords_buf[m++] );
             bb_coords.push_back(box);
             bb_labels.push_back(labels_buf[j]);
-        }
-        if(bb_coords.size() == 0)
-        {
-            std::cout<<"Zero BBoxes in Meta Node Resize";
-            bb_coords.push_back(temp_box);
-            bb_labels.push_back(0);
         }
         input_meta_data->get_bb_cords_batch()[i] = bb_coords;
         input_meta_data->get_bb_labels_batch()[i] = bb_labels;

--- a/rocAL/rocAL/source/meta_node_resize_crop_mirror.cpp
+++ b/rocAL/rocAL/source/meta_node_resize_crop_mirror.cpp
@@ -87,7 +87,7 @@ void ResizeCropMirrorMetaNode::update_parameters(MetaDataBatch* input_meta_data)
                 
                 if(_mirror_val[i] == 1)
                 {
-                   float l = 1 - box.r;
+                    float l = 1 - box.r;
                     float r = 1 - box.l;
                     box.l = l;
                     box.r = r;

--- a/rocAL/rocAL/source/meta_node_resize_crop_mirror.cpp
+++ b/rocAL/rocAL/source/meta_node_resize_crop_mirror.cpp
@@ -88,9 +88,8 @@ void ResizeCropMirrorMetaNode::update_parameters(MetaDataBatch* input_meta_data)
                 if(_mirror_val[i] == 1)
                 {
                     float l = 1 - box.r;
-                    float r = 1 - box.l;
+                    box.r = 1 - box.l;
                     box.l = l;
-                    box.r = r;
                 }                  
                 bb_coords.push_back(box);
                 bb_labels.push_back(labels_buf[j]);
@@ -98,10 +97,8 @@ void ResizeCropMirrorMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         }
         if(bb_coords.size() == 0)
         {
-            temp_box.l = 0;
-            temp_box.t = 0;
-            temp_box.r = 1;
-            temp_box.b = 1;
+            temp_box.l = temp_box.t = 0;
+            temp_box.r = temp_box.b = 1;
             bb_coords.push_back(temp_box);
             bb_labels.push_back(0);
         }

--- a/rocAL/rocAL/source/meta_node_resize_crop_mirror.cpp
+++ b/rocAL/rocAL/source/meta_node_resize_crop_mirror.cpp
@@ -63,37 +63,34 @@ void ResizeCropMirrorMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         BoundingBoxCord crop_box;
         _crop_w = _x2_val[i] - _x1_val[i];
         _crop_h = _y2_val[i] - _y1_val[i];
-        crop_box.x = _x1_val[i];
-        crop_box.y = _y1_val[i];
-        crop_box.w = _crop_w;
-        crop_box.h = _crop_h;
+        crop_box.l = _x1_val[i];
+        crop_box.t = _y1_val[i];
+        crop_box.r = _x2_val[i] ;
+        crop_box.b = _y2_val[i];
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
-            box.x = coords_buf[m++];
-            box.y = coords_buf[m++];
-            box.w = coords_buf[m++];
-            box.h = coords_buf[m++];
+            box.l = coords_buf[m++];
+            box.t = coords_buf[m++];
+            box.r = coords_buf[m++];
+            box.b = coords_buf[m++];
             if (BBoxIntersectionOverUnion(box, crop_box) >= _iou_threshold)
             {
-                float xA = std::max(crop_box.x, box.x);
-                float yA = std::max(crop_box.y, box.y);
-                float xB = std::min(crop_box.x + crop_box.w, box.x + box.w);
-                float yB = std::min(crop_box.y + crop_box.h, box.y + box.h);
-                box.x = xA - _x1_val[i];
-                box.y = yA - _y1_val[i];
-                box.w = xB - xA;
-                box.h = yB - yA;
-                _dst_to_src_width_ratio = _dst_width / float(_crop_w);
-                _dst_to_src_height_ratio = _dst_height / float(_crop_h);
-                box.x *= _dst_to_src_width_ratio;
-                box.y *= _dst_to_src_height_ratio;
-                box.w *= _dst_to_src_width_ratio;
-                box.h *= _dst_to_src_height_ratio;
+                float xA = std::max(crop_box.l, box.l);
+                float yA = std::max(crop_box.t, box.t);
+                float xB = std::min(crop_box.r, box.r);
+                float yB = std::min(crop_box.b, box.b);
+                box.l = (xA - crop_box.l) / (crop_box.r - crop_box.l);
+                box.t = (yA - crop_box.t) / (crop_box.b - crop_box.t);
+                box.r = (xB - crop_box.l) / (crop_box.r - crop_box.l);
+                box.b = (yB - crop_box.t) / (crop_box.b - crop_box.t);
+                
                 if(_mirror_val[i] == 1)
                 {
-                    float centre_x = _dst_width / 2;
-                    box.x += ((centre_x - box.x) * 2) - box.w;
+                   float l = 1 - box.r;
+                    float r = 1 - box.l;
+                    box.l = l;
+                    box.r = r;
                 }                  
                 bb_coords.push_back(box);
                 bb_labels.push_back(labels_buf[j]);
@@ -101,10 +98,10 @@ void ResizeCropMirrorMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         }
         if(bb_coords.size() == 0)
         {
-            temp_box.x = 0;
-            temp_box.y = 0;
-            temp_box.w =  crop_box.w - 1;
-	        temp_box.h =  crop_box.h - 1;
+            temp_box.l = 0;
+            temp_box.t = 0;
+            temp_box.r = 1;
+            temp_box.b = 1;
             bb_coords.push_back(temp_box);
             bb_labels.push_back(0);
         }

--- a/rocAL/rocAL/source/meta_node_rotate.cpp
+++ b/rocAL/rocAL/source/meta_node_rotate.cpp
@@ -51,13 +51,14 @@ void RotateMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         memcpy(coords_buf, input_meta_data->get_bb_cords_batch()[i].data(), input_meta_data->get_bb_cords_batch()[i].size() * sizeof(BoundingBoxCord));
         BoundingBoxCords bb_coords;
         BoundingBoxCord temp_box;
-        temp_box.x = temp_box.y = temp_box.w = temp_box.h = 0;
+        temp_box.l = temp_box.t =0;
+        temp_box.r = temp_box.b = 1;
         BoundingBoxLabels bb_labels;
         BoundingBoxCord dest_image;
-        dest_image.x = 0;
-        dest_image.y = 0;
-        dest_image.w = _dst_width;
-        dest_image.h = _dst_height;
+        dest_image.l = 0;
+        dest_image.t = 0;
+        dest_image.r = _dst_width;
+        dest_image.b = _dst_height;
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
@@ -89,20 +90,20 @@ void RotateMetaNode::update_parameters(MetaDataBatch* input_meta_data)
             min_y = std::min(y1, std::min(y2, std::min(y3, y4)));
             max_x = std::max(x1, std::max(x2, std::max(x3, x4)));
             max_y = std::max(y1, std::max(y2, std::max(y3, y4)));
-            box.x = (min_x > 0) ? min_x : 0;
-            box.y = (min_y > 0) ? min_y : 0;
-            box.w = max_x - box.x;
-            box.h = max_y - box.y;
+            box.l = (min_x > 0) ? min_x : 0;
+            box.t = (min_y > 0) ? min_y : 0;
+            box.r = max_x ;
+            box.b = max_y ;
             if (BBoxIntersectionOverUnion(box, dest_image) >= _iou_threshold)
             {
-                float xA = std::max(dest_image.x, box.x);
-                float yA = std::max(dest_image.y, box.y);
-                float xB = std::min(dest_image.x + dest_image.w, box.x + box.w);
-                float yB = std::min(dest_image.y + dest_image.h, box.y + box.h);
-                box.x = xA;
-                box.y = yA;
-                box.w = xB - xA;
-                box.h = yB - yA;
+                float xA = std::max(dest_image.l, box.l);
+                float yA = std::max(dest_image.t, box.t);
+                float xB = std::min(dest_image.r, box.r);
+                float yB = std::min(dest_image.b, box.b);
+                box.l = xA;
+                box.t = yA;
+                box.r = xB ;
+                box.b = yB ;
                 bb_coords.push_back(box);
                 bb_labels.push_back(labels_buf[j]);
             }

--- a/rocAL/rocAL/source/meta_node_rotate.cpp
+++ b/rocAL/rocAL/source/meta_node_rotate.cpp
@@ -51,12 +51,11 @@ void RotateMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         memcpy(coords_buf, input_meta_data->get_bb_cords_batch()[i].data(), input_meta_data->get_bb_cords_batch()[i].size() * sizeof(BoundingBoxCord));
         BoundingBoxCords bb_coords;
         BoundingBoxCord temp_box;
-        temp_box.l = temp_box.t =0;
+        temp_box.l = temp_box.t = 0;
         temp_box.r = temp_box.b = 1;
         BoundingBoxLabels bb_labels;
         BoundingBoxCord dest_image;
-        dest_image.l = 0;
-        dest_image.t = 0;
+        dest_image.l = dest_image.t = 0;
         dest_image.r = _dst_width;
         dest_image.b = _dst_height;
         for(uint j = 0, m = 0; j < bb_count; j++)
@@ -64,7 +63,7 @@ void RotateMetaNode::update_parameters(MetaDataBatch* input_meta_data)
             BoundingBoxCord box;
             float src_bb_x, src_bb_y, bb_w, bb_h;
             float dest_cx, dest_cy, src_cx, src_cy;
-            float x1, y1, x2, y2, x3, y3, x4, y4, min_x, min_y, max_x, max_y;
+            float x1, y1, x2, y2, x3, y3, x4, y4, min_x, min_y;
             float rotate[4];
             float radian = RAD(_angle_val[i]);
             rotate[0] = rotate[3] = cos(radian);
@@ -88,22 +87,16 @@ void RotateMetaNode::update_parameters(MetaDataBatch* input_meta_data)
             y4 = (rotate[2] * ((src_bb_x + bb_w) - src_cx))+( rotate[3] * ((src_bb_y + bb_h) - src_cy)) + dest_cy;
             min_x = std::min(x1, std::min(x2, std::min(x3, x4)));
             min_y = std::min(y1, std::min(y2, std::min(y3, y4)));
-            max_x = std::max(x1, std::max(x2, std::max(x3, x4)));
-            max_y = std::max(y1, std::max(y2, std::max(y3, y4)));
-            box.l = (min_x > 0) ? min_x : 0;
-            box.t = (min_y > 0) ? min_y : 0;
-            box.r = max_x ;
-            box.b = max_y ;
+            box.l = std::max(min_x, 0.0f);
+            box.t = std::max(min_y, 0.0f);
+            box.r = std::max(x1, std::max(x2, std::max(x3, x4))); ;
+            box.b = std::max(y1, std::max(y2, std::max(y3, y4)));
             if (BBoxIntersectionOverUnion(box, dest_image) >= _iou_threshold)
             {
-                float xA = std::max(dest_image.l, box.l);
-                float yA = std::max(dest_image.t, box.t);
-                float xB = std::min(dest_image.r, box.r);
-                float yB = std::min(dest_image.b, box.b);
-                box.l = xA;
-                box.t = yA;
-                box.r = xB ;
-                box.b = yB ;
+                box.l = std::max(dest_image.l, box.l);
+                box.t = std::max(dest_image.t, box.t);
+                box.r = std::min(dest_image.r, box.r) ;
+                box.b = std::min(dest_image.b, box.b) ;
                 bb_coords.push_back(box);
                 bb_labels.push_back(labels_buf[j]);
             }

--- a/rocAL/rocAL/source/meta_node_rotate.cpp
+++ b/rocAL/rocAL/source/meta_node_rotate.cpp
@@ -42,6 +42,7 @@ void RotateMetaNode::update_parameters(MetaDataBatch* input_meta_data)
     vxCopyArrayRange((vx_array)_src_width, 0, _batch_size, sizeof(uint),_src_width_val.data(), VX_READ_ONLY, VX_MEMORY_TYPE_HOST);
     vxCopyArrayRange((vx_array)_src_height, 0, _batch_size, sizeof(uint),_src_height_val.data(), VX_READ_ONLY, VX_MEMORY_TYPE_HOST);
     vxCopyArrayRange((vx_array)_angle, 0, _batch_size, sizeof(float),_angle_val.data(), VX_READ_ONLY, VX_MEMORY_TYPE_HOST);
+    BoundingBoxCord temp_box = {0, 0, 1, 1};
     for(int i = 0; i < _batch_size; i++)
     {
         auto bb_count = input_meta_data->get_bb_labels_batch()[i].size();
@@ -50,9 +51,6 @@ void RotateMetaNode::update_parameters(MetaDataBatch* input_meta_data)
         memcpy(labels_buf, input_meta_data->get_bb_labels_batch()[i].data(),  sizeof(int)*bb_count);
         memcpy(coords_buf, input_meta_data->get_bb_cords_batch()[i].data(), input_meta_data->get_bb_cords_batch()[i].size() * sizeof(BoundingBoxCord));
         BoundingBoxCords bb_coords;
-        BoundingBoxCord temp_box;
-        temp_box.l = temp_box.t = 0;
-        temp_box.r = temp_box.b = 1;
         BoundingBoxLabels bb_labels;
         BoundingBoxCord dest_image;
         dest_image.l = dest_image.t = 0;
@@ -95,8 +93,8 @@ void RotateMetaNode::update_parameters(MetaDataBatch* input_meta_data)
             {
                 box.l = std::max(dest_image.l, box.l);
                 box.t = std::max(dest_image.t, box.t);
-                box.r = std::min(dest_image.r, box.r) ;
-                box.b = std::min(dest_image.b, box.b) ;
+                box.r = std::min(dest_image.r, box.r);
+                box.b = std::min(dest_image.b, box.b);
                 bb_coords.push_back(box);
                 bb_labels.push_back(labels_buf[j]);
             }

--- a/rocAL/rocAL/source/meta_node_ssd_random_crop.cpp
+++ b/rocAL/rocAL/source/meta_node_ssd_random_crop.cpp
@@ -59,12 +59,10 @@ void SSDRandomCropMetaNode::update_parameters(MetaDataBatch *input_meta_data)
         //BoundingBoxCord temp_box;
         BoundingBoxLabels bb_labels;
         BoundingBoxCord crop_box;
-        //YTD
         crop_box.l = _x1_val[i];
         crop_box.t = _y1_val[i];
-        crop_box.r = _crop_width_val[i];
-        crop_box.b = _crop_height_val[i];
-
+        crop_box.r = _x1_val[i] + _crop_width_val[i];
+        crop_box.b = _y1_val[i] + _crop_height_val[i];
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
@@ -72,8 +70,8 @@ void SSDRandomCropMetaNode::update_parameters(MetaDataBatch *input_meta_data)
             box.t = coords_buf[m++];
             box.r = coords_buf[m++];
             box.b = coords_buf[m++];
-            auto x_c = 0.5f * ( 2 * box.r );
-            auto y_c = 0.5f * ( 2 * box.b );
+            auto x_c = 0.5f * (box.l + box.r);
+            auto y_c = 0.5f * (box.t + box.b);
             bool is_center_in_crop = (x_c >= crop_box.l && x_c <= crop_box.r) && (y_c >= crop_box.t && y_c <= crop_box.b);
             float bb_iou = BBoxIntersectionOverUnion(box, crop_box, entire_iou);
             if (bb_iou >= iou_range[j].first && bb_iou <= iou_range[j].second && is_center_in_crop)
@@ -82,10 +80,10 @@ void SSDRandomCropMetaNode::update_parameters(MetaDataBatch *input_meta_data)
                 float yA = std::max(crop_box.t, box.t);
                 float xB = std::min(crop_box.r, box.r);
                 float yB = std::min(crop_box.b, box.b);
-                box.l = xA - _x1_val[i];
-                box.t = yA - _y1_val[i];
-                box.r = xB - xA;
-                box.b = yB - yA;
+                box.l = (xA - crop_box.l) / (crop_box.r - crop_box.l);
+                box.t = (yA - crop_box.t) / (crop_box.b - crop_box.t);
+                box.r = (xB - crop_box.l) / (crop_box.r - crop_box.l);
+                box.b = (yB - crop_box.t) / (crop_box.b - crop_box.t);
                 bb_coords.push_back(box);
                 bb_labels.push_back(labels_buf[j]);
             }

--- a/rocAL/rocAL/source/meta_node_ssd_random_crop.cpp
+++ b/rocAL/rocAL/source/meta_node_ssd_random_crop.cpp
@@ -59,31 +59,33 @@ void SSDRandomCropMetaNode::update_parameters(MetaDataBatch *input_meta_data)
         //BoundingBoxCord temp_box;
         BoundingBoxLabels bb_labels;
         BoundingBoxCord crop_box;
-        crop_box.x = _x1_val[i];
-        crop_box.y = _y1_val[i];
-        crop_box.w = _crop_width_val[i];
-        crop_box.h = _crop_height_val[i];
+        //YTD
+        crop_box.l = _x1_val[i];
+        crop_box.t = _y1_val[i];
+        crop_box.r = _crop_width_val[i];
+        crop_box.b = _crop_height_val[i];
+
         for(uint j = 0, m = 0; j < bb_count; j++)
         {
             BoundingBoxCord box;
-            box.x = coords_buf[m++];
-            box.y = coords_buf[m++];
-            box.w = coords_buf[m++];
-            box.h = coords_buf[m++];
-            auto x_c = 0.5f * ( 2 * box.x + box.w );
-            auto y_c = 0.5f * ( 2 * box.y + box.h );
-            bool is_center_in_crop = (x_c >= crop_box.x && x_c <= crop_box.x + crop_box.w) && (y_c >= crop_box.y && y_c <= crop_box.y + crop_box.h);
+            box.l = coords_buf[m++];
+            box.t = coords_buf[m++];
+            box.r = coords_buf[m++];
+            box.b = coords_buf[m++];
+            auto x_c = 0.5f * ( 2 * box.r );
+            auto y_c = 0.5f * ( 2 * box.b );
+            bool is_center_in_crop = (x_c >= crop_box.l && x_c <= crop_box.r) && (y_c >= crop_box.t && y_c <= crop_box.b);
             float bb_iou = BBoxIntersectionOverUnion(box, crop_box, entire_iou);
             if (bb_iou >= iou_range[j].first && bb_iou <= iou_range[j].second && is_center_in_crop)
             {
-                float xA = std::max(crop_box.x, box.x);
-                float yA = std::max(crop_box.y, box.y);
-                float xB = std::min(crop_box.x + crop_box.w, box.x + box.w);
-                float yB = std::min(crop_box.y + crop_box.h, box.y + box.h);
-                box.x = xA - _x1_val[i];
-                box.y = yA - _y1_val[i];
-                box.w = xB - xA;
-                box.h = yB - yA;
+                float xA = std::max(crop_box.l, box.l);
+                float yA = std::max(crop_box.t, box.t);
+                float xB = std::min(crop_box.r, box.r);
+                float yB = std::min(crop_box.b, box.b);
+                box.l = xA - _x1_val[i];
+                box.t = yA - _y1_val[i];
+                box.r = xB - xA;
+                box.b = yB - yA;
                 bb_coords.push_back(box);
                 bb_labels.push_back(labels_buf[j]);
             }

--- a/rocAL/rocAL/source/node_ssd_random_crop.cpp
+++ b/rocAL/rocAL/source/node_ssd_random_crop.cpp
@@ -111,8 +111,8 @@ void SSDRandomCropNode::update_node()
             {
                 crop_box.l = 0;
                 crop_box.t = 0;
-                crop_box.r = in_height[i];
-                crop_box.b = in_width[i];
+                crop_box.r = 1;
+                crop_box.b = 1;
                 break;
             }
             for (int j = 0; j < _num_of_attempts; j++)

--- a/rocAL/rocAL/source/node_ssd_random_crop.cpp
+++ b/rocAL/rocAL/source/node_ssd_random_crop.cpp
@@ -42,18 +42,14 @@ inline double ssd_BBoxIntersectionOverUnion(const BoundingBoxCord &box1, const B
     float yA = std::max(box1.t, box2.t);
     float xB = std::min(box1.r, box2.r);
     float yB = std::min(box1.b, box2.b);
-
     float intersection_area = std::max((float)0.0, xB - xA) * std::max((float)0.0, yB - yA);
     float box1_h, box1_w, box2_h, box2_w;
     box1_w = box1.r - box1.l;
     box2_w = box2.r - box2.l;
     box1_h = box1.b - box1.t;
     box2_h = box2.b - box2.t;
-
-
     float box1_area = box1_h * box1_w;
     float box2_area = box2_h * box2_w;
-
     if (is_iou)
         iou = intersection_area / float(box1_area + box2_area - intersection_area);
     else
@@ -99,7 +95,6 @@ void SSDRandomCropNode::update_node()
         crop_box.r = _x1_val[i] + _crop_width_val[i];
         crop_box.l = _x1_val[i];
         crop_box.t = _y1_val[i];
-
         while (true)
         {
             sample_option = dis(gen);
@@ -187,11 +182,6 @@ void SSDRandomCropNode::update_node()
     vxCopyArrayRange((vx_array)_crop_param->croph_arr, 0, _batch_size, sizeof(uint), _crop_height_val.data(), VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST);
     vxCopyArrayRange((vx_array)_crop_param->x1_arr, 0, _batch_size, sizeof(uint), _x1_val.data(), VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST);
     vxCopyArrayRange((vx_array)_crop_param->y1_arr, 0, _batch_size, sizeof(uint), _y1_val.data(), VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST);
-    // std::cerr<<"\n Crop values after ssd ::";
-    // for(int i = 0; i < _batch_size; i++)
-    // {
-    //     std::cerr<<"\n "<<_x1_val[i]<<"\t"<<_y1_val[i]<<"\t"<<_crop_width_val[i]<<"\t"<<_crop_height_val[i];
-    // }
     _outputs[0]->update_image_roi(_crop_width_val, _crop_height_val);  
 }
 

--- a/rocAL/rocAL/source/node_ssd_random_crop.cpp
+++ b/rocAL/rocAL/source/node_ssd_random_crop.cpp
@@ -111,6 +111,7 @@ void SSDRandomCropNode::update_node()
                 crop_box.b = 1;
                 break;
             }
+            float aspect_ratio;
             for (int j = 0; j < _num_of_attempts; j++)
             {
                 
@@ -118,11 +119,11 @@ void SSDRandomCropNode::update_node()
                 float w_factor = _float_dis(_rngs[sample]);
                 float h_factor = _float_dis(_rngs[sample]);
                 //aspect ratio check
-                if ((w_factor / h_factor < 0.5) || (w_factor / h_factor > 2.))
+                aspect_ratio = w_factor/h_factor;
+                if ((aspect_ratio < 0.5) || (aspect_ratio > 2.))
                     continue;
-                break;
             }
-            if ((w_factor / h_factor < 0.5) || (w_factor / h_factor > 2.))
+            if ((aspect_ratio < 0.5) || (aspect_ratio > 2.))
                 continue;
             
             

--- a/rocAL/rocAL/source/node_ssd_random_crop.cpp
+++ b/rocAL/rocAL/source/node_ssd_random_crop.cpp
@@ -38,17 +38,23 @@ void SSDRandomCropNode::create_node()
 inline double ssd_BBoxIntersectionOverUnion(const BoundingBoxCord &box1, const BoundingBoxCord &box2, bool is_iou = false) 
 {
     double iou;
-    float xA = std::max(box1.x, box2.x);
-    float yA = std::max(box1.y, box2.y);
-    float xB = std::min(box1.x + box1.w, box2.x + box2.w);
-    float yB = std::min(box1.y + box1.h, box2.y + box2.h);
+    float xA = std::max(box1.l, box2.l);
+    float yA = std::max(box1.t, box2.t);
+    float xB = std::min(box1.r, box2.r);
+    float yB = std::min(box1.b, box2.b);
 
     float intersection_area = std::max((float)0.0, xB - xA) * std::max((float)0.0, yB - yA);
+    float box1_h, box1_w, box2_h, box2_w;
+    box1_w = box1.r - box1.l;
+    box2_w = box2.r - box2.l;
+    box1_h = box1.b - box1.t;
+    box2_h = box2.b - box2.t;
 
-    float box1_area = box1.h * box1.w;
-    float box2_area = box2.h * box2.w;
 
-    if(is_iou)
+    float box1_area = box1_h * box1_w;
+    float box2_area = box2_h * box2_w;
+
+    if (is_iou)
         iou = intersection_area / float(box1_area + box2_area - intersection_area);
     else
         iou = intersection_area / float(box1_area);
@@ -87,10 +93,12 @@ void SSDRandomCropNode::update_node()
         memcpy(labels_buf.data(), _meta_data_info->get_bb_labels_batch()[i].data(), sizeof(int) * bb_count);
         std::vector<float> coords_buf(bb_count * 4);
         memcpy(coords_buf.data(), _meta_data_info->get_bb_cords_batch()[i].data(), _meta_data_info->get_bb_cords_batch()[i].size() * sizeof(BoundingBoxCord));
-        crop_box.h = _crop_height_val[i];
-        crop_box.w = _crop_width_val[i];
-        crop_box.x = _x1_val[i];
-        crop_box.y = _y1_val[i];
+        //YTD
+        crop_box.b = _y1_val[i] + _crop_height_val[i];
+        crop_box.r = _x1_val[i]+ _crop_width_val[i];
+        crop_box.l = _x1_val[i];
+        crop_box.t = _y1_val[i];
+
         while (true)
         {
             sample_option = dis(gen);
@@ -101,10 +109,10 @@ void SSDRandomCropNode::update_node()
             //sample_option = 0;
             if (!sample_option)
             {
-                crop_box.x = 0;
-                crop_box.y = 0;
-                crop_box.h = in_height[i];
-                crop_box.w = in_width[i];
+                crop_box.l = 0;
+                crop_box.t = 0;
+                crop_box.r = in_height[i];
+                crop_box.b = in_width[i];
                 break;
             }
             for (int j = 0; j < _num_of_attempts; j++)
@@ -112,33 +120,36 @@ void SSDRandomCropNode::update_node()
                 x_drift_factor->renew();
                 float factor = 0.3f;
                 auto w_factor = factor + (x_drift_factor->get() * (1 - factor));
-                crop_box.w = w_factor * in_width[i];
+                //YTD
+                crop_box.r = w_factor * in_width[i];
                 y_drift_factor->renew();
                 y_drift_factor->renew();
                 auto h_factor = factor + (y_drift_factor->get() * (1 - factor));
-                crop_box.h = h_factor * in_height[i];
+                //YTD
+                crop_box.r = h_factor * in_height[i];
                 //aspect ratio check
-                if ((crop_box.w / crop_box.h < 0.5) || (crop_box.w / crop_box.h > 2.))
+                if ((crop_box.r / crop_box.b < 0.5) || (crop_box.r / crop_box.b > 2.))
                     continue;
                 break;
             }
-            if ((crop_box.w / crop_box.h < 0.5) || (crop_box.w / crop_box.h > 2.))
+            if ((crop_box.r / crop_box.b < 0.5) || (crop_box.r / crop_box.b > 2.))
                 continue;
             //Got the crop;
             x_drift_factor->renew();
             x_drift_factor->renew();
             y_drift_factor->renew();
-            crop_box.x = static_cast<size_t>(x_drift_factor->get() * (in_width[i] - crop_box.w));
-            crop_box.y = static_cast<size_t>(y_drift_factor->get() * (in_height[i] - crop_box.h));
+            crop_box.l = static_cast<size_t>(x_drift_factor->get() * (in_width[i] - crop_box.r));
+            crop_box.t = static_cast<size_t>(y_drift_factor->get() * (in_height[i] - crop_box.b));
             invalid_bboxes = false;
 
             for (int j = 0; j < bb_count; j++)
             {
                 int m = j * 4;
-                jth_box.x = coords_buf[m];
-                jth_box.y = coords_buf[m + 1];
-                jth_box.w = coords_buf[m + 2];
-                jth_box.h = coords_buf[m + 3];
+                jth_box.l = coords_buf[m];
+                jth_box.t = coords_buf[m + 1];
+                jth_box.r = coords_buf[m + 2];
+                jth_box.b = coords_buf[m + 3];
+                
                 float bb_iou = ssd_BBoxIntersectionOverUnion(jth_box, crop_box, _entire_iou); 
                 if (bb_iou < min_iou || bb_iou > max_iou )
                 {
@@ -150,7 +161,10 @@ void SSDRandomCropNode::update_node()
             if (invalid_bboxes)
                 continue;
             int valid_bbox_count = 0;
-            auto left = crop_box.x, top = crop_box.y, right = crop_box.x + crop_box.w, bottom = crop_box.y + crop_box.h;
+            auto left = crop_box.l;
+            auto top = crop_box.t;
+            auto right = crop_box.r;
+            auto bottom = crop_box.b;
             for (int j = 0; j < bb_count; j++)
             {
                 int m = j * 4;
@@ -163,12 +177,12 @@ void SSDRandomCropNode::update_node()
                 continue;
             break;
         } // while loop
-        _x1_val[i] = crop_box.x;
-        _y1_val[i] = crop_box.y;
-        _crop_width_val[i] = crop_box.w;
-        _crop_height_val[i] = crop_box.h;
-        _x2_val[i] = _x1_val[i] + crop_box.w;
-        _y2_val[i] = _y2_val[i] + crop_box.h;
+        _x1_val[i] = crop_box.l;
+        _y1_val[i] = crop_box.t;
+        _crop_width_val[i] = crop_box.l;
+        _crop_height_val[i] = crop_box.l;
+        _x2_val[i] = crop_box.r;
+        _y2_val[i] = crop_box.b;
 
     }
     vxCopyArrayRange((vx_array)_crop_param->cropw_arr, 0, _batch_size, sizeof(uint), _crop_width_val.data(), VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST);

--- a/rocAL/rocAL/source/rali_api_meta_data.cpp
+++ b/rocAL/rocAL/source/rali_api_meta_data.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include "rali_api.h"
 
 void
-RALI_API_CALL raliRandomBBoxCrop(RaliContext p_context, bool all_boxes_overlap, bool no_crop, RaliFloatParam p_aspect_ratio, bool has_shape, int crop_width, int crop_height, int num_attempts, RaliFloatParam p_scaling, int total_num_attempts) 
+RALI_API_CALL raliRandomBBoxCrop(RaliContext p_context, bool all_boxes_overlap, bool no_crop, RaliFloatParam p_aspect_ratio, bool has_shape, int crop_width, int crop_height, int num_attempts, RaliFloatParam p_scaling, int total_num_attempts, int64_t seed)
 {
     if (!p_context)
         THROW("Invalid rali context passed to raliRandomBBoxCrop")
@@ -53,7 +53,7 @@ RALI_API_CALL raliRandomBBoxCrop(RaliContext p_context, bool all_boxes_overlap, 
     {
         scaling = static_cast<FloatParam*>(p_scaling);        
     }
-    context->master_graph->create_randombboxcrop_reader(RandomBBoxCrop_MetaDataReaderType::RandomBBoxCropReader, RandomBBoxCrop_MetaDataType::BoundingBox, all_boxes_overlap, no_crop, aspect_ratio, has_shape, crop_width, crop_height, num_attempts, scaling, total_num_attempts);
+    context->master_graph->create_randombboxcrop_reader(RandomBBoxCrop_MetaDataReaderType::RandomBBoxCropReader, RandomBBoxCrop_MetaDataType::BoundingBox, all_boxes_overlap, no_crop, aspect_ratio, has_shape, crop_width, crop_height, num_attempts, scaling, total_num_attempts, seed);
 }
 
 RaliMetaData

--- a/rocAL/rocAL/source/randombboxcrop_reader.cpp
+++ b/rocAL/rocAL/source/randombboxcrop_reader.cpp
@@ -114,7 +114,7 @@ pCropCord RandomBBoxCropReader::get_crop_cord(const std::string &image_name)
 
 void RandomBBoxCropReader::add(std::string image_name, BoundingBoxCord crop_box)
 {
-    pCropCord random_bbox_cords = std::make_shared<CropCord>(std::round(crop_box.x), std::round(crop_box.y), std::round(crop_box.w), std::round(crop_box.h));
+    pCropCord random_bbox_cords = std::make_shared<CropCord>(crop_box.x, crop_box.y, crop_box.w, crop_box.h);
     if (exists(image_name))
     {
         return;

--- a/rocAL/rocAL/source/randombboxcrop_reader.cpp
+++ b/rocAL/rocAL/source/randombboxcrop_reader.cpp
@@ -238,7 +238,7 @@ void RandomBBoxCropReader::read_all()
                 break;
         } // while loop
 
-        std::cout << image_name << " wxh: " << in_width << "X" << in_height << " crop<x,y, w, h>: " << crop_box.x << " X " << crop_box.y << " X " << crop_box.w << " X " << crop_box.h << std::endl;  
+//        std::cout << image_name << " wxh: " << in_width << "X" << in_height << " crop<x,y, w, h>: " << crop_box.x << " X " << crop_box.y << " X " << crop_box.w << " X " << crop_box.h << std::endl;  
         add(image_name, crop_box);
         sample++;
     }

--- a/rocAL/rocAL/source/randombboxcrop_reader.cpp
+++ b/rocAL/rocAL/source/randombboxcrop_reader.cpp
@@ -27,30 +27,11 @@ THE SOFTWARE.
 #include <algorithm>
 #include <fstream>
 
-//using namespace std;
-
 void RandomBBoxCropReader::init(const RandomBBoxCrop_MetaDataConfig &cfg)
 {
-    _crop_param = std::make_shared<RaliRandomCropParam>(_batch_size);
-    _crop_param->set_x_drift_factor(core(x_drift));
-    _crop_param->set_y_drift_factor(core(y_drift));
-    _crop_param->set_area_factor(core(cfg.scaling()));
-    _crop_param->set_aspect_ratio(core(cfg.aspect_ratio()));
     _all_boxes_overlap = cfg.all_boxes_overlap();
     _no_crop = cfg.no_crop();
     _has_shape = cfg.has_shape();
-    _crop_width = cfg.crop_width();
-    _crop_height = cfg.crop_height();
-    _crop_width_val.resize(_batch_size);
-    _crop_height_val.resize(_batch_size);
-    _x1_val.resize(_batch_size);
-    _y1_val.resize(_batch_size);
-    _x2_val.resize(_batch_size);
-    _y2_val.resize(_batch_size);
-    _iou_range.resize(_batch_size);
-    in_width.resize(_batch_size);
-    in_height.resize(_batch_size);
-    _crop_param->array_init();
     if (cfg.num_attempts() > 1)
     {
         _num_of_attempts = cfg.num_attempts();
@@ -60,6 +41,8 @@ void RandomBBoxCropReader::init(const RandomBBoxCrop_MetaDataConfig &cfg)
         _total_num_of_attempts = cfg.total_num_attempts();
     }
     _output = new CropCordBatch();
+    _user_batch_size = 128;   // todo:: get it from master graph
+    _seed = cfg.seed();
 }
 
 void RandomBBoxCropReader::set_meta_data(std::shared_ptr<MetaDataReader> meta_data_reader)
@@ -131,10 +114,9 @@ pCropCord RandomBBoxCropReader::get_crop_cord(const std::string &image_name)
 
 void RandomBBoxCropReader::add(std::string image_name, BoundingBoxCord crop_box)
 {
-    pCropCord random_bbox_cords = std::make_shared<CropCord>(crop_box.x, crop_box.y, crop_box.w, crop_box.h);
+    pCropCord random_bbox_cords = std::make_shared<CropCord>(std::round(crop_box.x), std::round(crop_box.y), std::round(crop_box.w), std::round(crop_box.h));
     if (exists(image_name))
     {
-        // auto it = _map_content.find(image_name);
         return;
     }
     _map_content.insert(std::pair<std::string, std::shared_ptr<CropCord>>(image_name, random_bbox_cords));
@@ -155,148 +137,110 @@ void RandomBBoxCropReader::print_map_contents()
 
 void RandomBBoxCropReader::read_all()
 {
-    std::random_device rd;
-    std::mt19937 gen(rd());
-    std::uniform_int_distribution<> dis(0, 7);
-
-    const std::vector<float> sample_options = {0.0f, 0.1f, 0.3f, 0.5f, 0.7f, 0.9f, -1.0f};
+    const std::vector<float> sample_options = {-1.0f, 0.1f, 0.3f, 0.5f, 0.7f, 0.9f, 0.0f};
     int sample_option;
     std::pair<bool, float> option;
-    float min_iou; // max_iou;
+    float min_iou;
     bool invalid_bboxes;
     bool crop_success;
-    BoundingBoxCord crop_box, jth_box;
+    BoundingBoxCord crop_box;
     uint bb_count;
     _meta_bbox_map_content = _meta_data_reader->get_map_content();
-    int i = 0;
-    Parameter<float> *width_factor_param, *height_factor_param;
-    // srand here
-    width_factor_param = ParameterFactory::instance()->create_uniform_float_rand_param(0.3, 1.0)->core;
-    height_factor_param = ParameterFactory::instance()->create_uniform_float_rand_param(0.3, 1.0)->core;
+    std::uniform_int_distribution<> option_dis(0, 6);
+    std::uniform_real_distribution<float> _float_dis(0.3, 1.0);
 
+    size_t sample = 0;
     for (auto &elem : _meta_bbox_map_content)
     {
+        uint32_t in_width, in_height;
         std::string image_name = elem.first;
         BoundingBoxCords bb_coords = elem.second->get_bb_cords();
         ImgSizes img_sizes = elem.second->get_img_sizes();
-        in_width[i] = img_sizes[i].w;
-        in_height[i] = img_sizes[i].h;
+        in_width = img_sizes[0].w;
+        in_height = img_sizes[0].h;
         bb_count = bb_coords.size();
-        std::vector<float> coords_buf(bb_count * 4);
-        for (unsigned int j = 0, m = 0; j < bb_count; j++, m += 4)
-        {
-            coords_buf[m] = bb_coords[j].x;
-            coords_buf[m + 1] = bb_coords[j].y;
-            coords_buf[m + 2] = bb_coords[j].w;
-            coords_buf[m + 3] = bb_coords[j].h;
-        }
-
         while (true)
         {
             crop_success = false;
-            sample_option = dis(gen);
+            sample_option = option_dis(_rngs[sample]);
             min_iou = sample_options[sample_option];
-            Parameter<float> *x_factor_param, *y_factor_param;
             invalid_bboxes = false;
 
             //Condition for Original Image
-            if (sample_option == 0)
+            if (sample_option == 6 || _has_shape)
             {
                 crop_box.x = 0;
                 crop_box.y = 0;
-                crop_box.w = in_width[i];
-                crop_box.h = in_height[i];
+                crop_box.w = in_width;
+                crop_box.h = in_height;
                 break;
             }
 
-            if (_has_shape)
+            // If it has no shape, then area and aspect ratio thing should be provided
+            for (int j = 0; j < 1; j++)
             {
-                crop_box.x = 0;
-                crop_box.y = 0;
-                crop_box.w = in_width[i];
-                crop_box.h = in_height[i];
-                break;
-            }
-            else // If it has no shape, then area and aspect ratio thing should be provided
-            {
-                for (int j = 0; j < 1; j++)
+                // Setting width and height factor btw 0.3 and 1.0";
+                float width_factor = _float_dis(_rngs[sample]);
+                float height_factor = _float_dis(_rngs[sample]);
+                if ((width_factor / height_factor < 0.5) || (width_factor / height_factor > 2.))
                 {
-                    // Setting width factor btw 0.3 and 1.0";
-                    width_factor_param->renew();
-                    float width_factor = width_factor_param->get();
-                    // Setting height factor btw 0.3 and 1.0";
-                    height_factor_param->renew();
-                    float height_factor = height_factor_param->get();
-                    if ((width_factor / height_factor < 0.5) || (width_factor / height_factor > 2.))
-                    {
-                        continue;
-                    }
-                    // Setting width factor btw 0 and 1 - width_factor
-                    x_factor_param = ParameterFactory::instance()->create_uniform_float_rand_param(0, 1 - width_factor)->core;
-                    x_factor_param->renew();
-                    float x_factor = x_factor_param->get();
-                    // Setting height factor btw 0 and 1 - width_factor
-                    y_factor_param = ParameterFactory::instance()->create_uniform_float_rand_param(0, 1 - height_factor)->core;
-                    y_factor_param->renew();
-                    float y_factor = y_factor_param->get();
-                    crop_box.x = x_factor * in_width[i];
-                    crop_box.y = y_factor * in_height[i];
-                    crop_box.w = width_factor * in_width[i];
-                    crop_box.h = height_factor * in_height[i];
-                    // All boxes should satisfy IOU criteria
-                    if (_all_boxes_overlap)
-                    {
-                        for (uint j = 0; j < bb_count; j++)
-                        {
-                            int m = j * 4;
-                            jth_box.x = coords_buf[m];
-                            jth_box.y = coords_buf[m + 1];
-                            jth_box.w = coords_buf[m + 2];
-                            jth_box.h = coords_buf[m + 3];
-
-                            float bb_iou = ssd_BBoxIntersectionOverUnion(jth_box, crop_box, true);
-                            if (bb_iou < min_iou)
-                            {
-                                invalid_bboxes = true;
-                                break;
-                            }
-                        }
-                        if (invalid_bboxes)
-                        {
-                            continue; // Goes to for loop
-                        }
-                    }
-
-                    // Mask Condition
-                    int valid_bbox_count = 0;
-                    auto left = int(crop_box.x);
-                    auto top = crop_box.y;
-                    auto right = int(crop_box.x) + int(crop_box.w);
-                    auto bottom = crop_box.y + crop_box.h;
-                    valid_bbox_count = 0;
+                    continue;
+                }
+                // Setting width factor btw 0 and 1 - width_factor and height factor btw 0 and 1 - height_factor
+                std::uniform_real_distribution<float> l_dis(0.0, 1.0 - width_factor), t_dis(0.0, 1.0-height_factor);
+                float x_factor = l_dis(_rngs[sample]);
+                float y_factor = t_dis(_rngs[sample]);
+                crop_box.x = x_factor*in_width;
+                crop_box.y = y_factor*in_height;
+                crop_box.w = width_factor*in_width;
+                crop_box.h = height_factor*in_height;
+                //std::cout << "random crop params < option, xfactor, yfactor, wf, hf>: " << sample_option << " " << x_factor << " " << y_factor << " " << width_factor << " " << height_factor << std::endl;
+                // All boxes should satisfy IOU criteria
+                if (_all_boxes_overlap)
+                {
                     for (uint j = 0; j < bb_count; j++)
                     {
-                        int m = j * 4;
-                        auto x_c = 0.5f * (2 * coords_buf[m] + coords_buf[m + 2]);
-                        auto y_c = 0.5f * (2 * coords_buf[m + 1] + coords_buf[m + 3]);
-                        if ((x_c > left) && (x_c < right) && (y_c > top) && (y_c < bottom))
+                        float bb_iou = ssd_BBoxIntersectionOverUnion(bb_coords[j], crop_box, true);
+                        if (bb_iou < min_iou)
                         {
-                            valid_bbox_count++;
+                            invalid_bboxes = true;
+                            break;
                         }
                     }
-                    if (valid_bbox_count == 0)
-                        break;
-
-                    crop_success = true;
-                    break;
+                    if (invalid_bboxes)
+                    {
+                        continue; // Goes to for loop
+                    }
                 }
+
+                // Mask Condition
+                int valid_bbox_count = 0;
+                auto right = crop_box.x + crop_box.w;
+                auto bottom = crop_box.y + crop_box.h;
+                valid_bbox_count = 0;
+                for (uint j = 0; j < bb_count; j++)
+                {
+                    auto x_c = bb_coords[j].x + 0.5f *bb_coords[j].w;
+                    auto y_c = bb_coords[j].y + 0.5f *bb_coords[j].h;
+                    if ((x_c > crop_box.x) && (x_c < right) && (y_c > crop_box.y) && (y_c < bottom))
+                    {
+                        valid_bbox_count++;
+                    }
+                }
+                if (valid_bbox_count == 0)
+                    break;
+
+                crop_success = true;
+                break;
             }
 
             if (crop_success == true)
                 break;
         } // while loop
 
+        std::cout << image_name << " wxh: " << in_width << "X" << in_height << " crop<x,y, w, h>: " << crop_box.x << " X " << crop_box.y << " X " << crop_box.w << " X " << crop_box.h << std::endl;  
         add(image_name, crop_box);
+        sample++;
     }
 }
 
@@ -305,6 +249,7 @@ void RandomBBoxCropReader::release()
     _map_content.clear();
 }
 
-RandomBBoxCropReader::RandomBBoxCropReader()
+RandomBBoxCropReader::RandomBBoxCropReader() :
+      _rngs(128)
 {
 }

--- a/rocAL/rocAL/source/randombboxcrop_reader.cpp
+++ b/rocAL/rocAL/source/randombboxcrop_reader.cpp
@@ -64,15 +64,8 @@ inline double ssd_BBoxIntersectionOverUnion(const BoundingBoxCord &box1, const B
     float yB = std::min(box1.b, box2.b);
 
     float intersection_area = std::max((float)0.0, xB - xA) * std::max((float)0.0, yB - yA);
-    float box1_h, box1_w, box2_h, box2_w;
-    box1_w = box1.r - box1.l;
-    box2_w = box2.r - box2.l;
-    box1_h = box1.b - box1.t;
-    box2_h = box2.b - box2.t;
-
-
-    float box1_area = box1_h * box1_w;
-    float box2_area = box2_h * box2_w;
+    float box1_area = (box1.b - box1.t) * (box1.r - box1.l);
+    float box2_area = (box2.b - box2.t) * (box2.r - box2.l);
 
     if (is_iou)
         iou = intersection_area / float(box1_area + box2_area - intersection_area);

--- a/rocAL/rocAL/source/randombboxcrop_reader.cpp
+++ b/rocAL/rocAL/source/randombboxcrop_reader.cpp
@@ -171,8 +171,8 @@ void RandomBBoxCropReader::read_all()
             {
                 crop_box.x = 0;
                 crop_box.y = 0;
-                crop_box.w = in_width;
-                crop_box.h = in_height;
+                crop_box.w = 1;
+                crop_box.h = 1;
                 break;
             }
 
@@ -190,10 +190,10 @@ void RandomBBoxCropReader::read_all()
                 std::uniform_real_distribution<float> l_dis(0.0, 1.0 - width_factor), t_dis(0.0, 1.0-height_factor);
                 float x_factor = l_dis(_rngs[sample]);
                 float y_factor = t_dis(_rngs[sample]);
-                crop_box.x = x_factor*in_width;
-                crop_box.y = y_factor*in_height;
-                crop_box.w = width_factor*in_width;
-                crop_box.h = height_factor*in_height;
+                crop_box.x = x_factor;
+                crop_box.y = y_factor;
+                crop_box.w = width_factor;
+                crop_box.h = height_factor;
                 //std::cout << "random crop params < option, xfactor, yfactor, wf, hf>: " << sample_option << " " << x_factor << " " << y_factor << " " << width_factor << " " << height_factor << std::endl;
                 // All boxes should satisfy IOU criteria
                 if (_all_boxes_overlap)
@@ -239,6 +239,11 @@ void RandomBBoxCropReader::read_all()
         } // while loop
 
 //        std::cout << image_name << " wxh: " << in_width << "X" << in_height << " crop<x,y, w, h>: " << crop_box.x << " X " << crop_box.y << " X " << crop_box.w << " X " << crop_box.h << std::endl;  
+        crop_box.x = crop_box.x*in_width;
+        crop_box.y = crop_box.y*in_height;
+        crop_box.w = crop_box.w*in_width;
+        crop_box.h = crop_box.h*in_height;
+        
         add(image_name, crop_box);
         sample++;
     }

--- a/rocAL/rocAL/source/randombboxcrop_reader.cpp
+++ b/rocAL/rocAL/source/randombboxcrop_reader.cpp
@@ -159,12 +159,10 @@ void RandomBBoxCropReader::read_all()
     size_t sample = 0;
     for (auto &elem : _meta_bbox_map_content)
     {
-        uint32_t in_width, in_height;
+        
         std::string image_name = elem.first;
         BoundingBoxCords bb_coords = elem.second->get_bb_cords();
         ImgSizes img_sizes = elem.second->get_img_sizes();
-        in_width = img_sizes[0].w;
-        in_height = img_sizes[0].h;
         bb_count = bb_coords.size();
         while (true)
         {

--- a/rocAL/rocAL/source/tf_meta_data_reader_detection.cpp
+++ b/rocAL/rocAL/source/tf_meta_data_reader_detection.cpp
@@ -206,10 +206,10 @@ void TFMetaDataReaderDetection::read_record(std::ifstream &file_contents, uint f
       bbox_ymin = sf_ymin.float_list().value()[i];
       bbox_xmax = sf_xmax.float_list().value()[i];
       bbox_ymax = sf_ymax.float_list().value()[i]; 
-      box.l = bbox_xmin * image_width;
-      box.t = (bbox_xmax * image_width) - box.l;
-      box.r = bbox_ymin * image_height;
-      box.b = (bbox_ymax * image_height) - box.t;
+      box.l = bbox_xmin ;
+      box.r = bbox_xmax ;
+      box.t = bbox_ymin ;
+      box.b = bbox_ymax ;
       bb_coords.push_back(box);
       bb_labels.push_back(label);
       add(fname, bb_coords, bb_labels,img_sizes);

--- a/rocAL/rocAL/source/tf_meta_data_reader_detection.cpp
+++ b/rocAL/rocAL/source/tf_meta_data_reader_detection.cpp
@@ -84,7 +84,8 @@ void TFMetaDataReaderDetection::lookup(const std::vector<std::string> &image_nam
             ImgSize img_size;
 
 
-            box.x = box.y = box.w = box.h = 0;
+            box.l = box.t = 0;
+            box.r = box.b = 1;
             img_size.w = img_size.h =0;
             bb_coords.push_back(box);
             bb_labels.push_back(0);
@@ -118,7 +119,7 @@ void TFMetaDataReaderDetection::print_map_contents()
         bb_labels = elem.second->get_bb_labels();
         std::cerr << "\nsize of the element  : "<< bb_coords.size() << std::endl;
         for(unsigned int i = 0; i < bb_coords.size(); i++){
-            std::cerr << " x : " << bb_coords[i].x << " y: :" << bb_coords[i].y << " width : " << bb_coords[i].w << " height: :" << bb_coords[i].h << std::endl;
+            std::cerr << " l : " << bb_coords[i].l << " t: :" << bb_coords[i].t << " r : " << bb_coords[i].r << " b: :" << bb_coords[i].b << std::endl;
             std::cerr  << "Label Id : " << bb_labels[i] << std::endl;
         }
     }
@@ -205,10 +206,10 @@ void TFMetaDataReaderDetection::read_record(std::ifstream &file_contents, uint f
       bbox_ymin = sf_ymin.float_list().value()[i];
       bbox_xmax = sf_xmax.float_list().value()[i];
       bbox_ymax = sf_ymax.float_list().value()[i]; 
-      box.x = bbox_xmin * image_width;
-      box.w = (bbox_xmax * image_width) - box.x;
-      box.y = bbox_ymin * image_height;
-      box.h = (bbox_ymax * image_height) - box.y;
+      box.l = bbox_xmin * image_width;
+      box.t = (bbox_xmax * image_width) - box.l;
+      box.r = bbox_ymin * image_height;
+      box.b = (bbox_ymax * image_height) - box.t;
       bb_coords.push_back(box);
       bb_labels.push_back(label);
       add(fname, bb_coords, bb_labels,img_sizes);

--- a/rocAL/rocAL_pybind/amd/rali/ops.py
+++ b/rocAL/rocAL_pybind/amd/rali/ops.py
@@ -839,7 +839,7 @@ class ImageDecoderSlice(Node):
             elif(self.prev.prev.data == "COCOReader") :
                 obj = self.crop_begin
                 obj.rali_c_func_call(handle)
-                output_image = b.COCO_ImageDecoderSliceShard(handle, input_image[0], input_image[1], types.RGB, shard_id, num_shards, is_output, shuffle, False,types.USER_GIVEN_SIZE, multiplier*decode_width, multiplier*decode_height, None, None, None, None)
+                output_image = b.COCO_ImageDecoderSliceShard(handle, input_image[0], input_image[1], types.RGB, shard_id, num_shards, is_output, shuffle, False, types.MAX_SIZE, multiplier*decode_width, multiplier*decode_height, None, None, None, None)
             else:
                 output_image = b.ImageDecoderShard(handle, input_image, types.RGB, shard_id, num_shards,  is_output, shuffle, False, types.USER_GIVEN_SIZE, multiplier*decode_width, multiplier*decode_height)
         else:

--- a/rocAL/rocAL_pybind/example/coco_pipeline.py
+++ b/rocAL/rocAL_pybind/example/coco_pipeline.py
@@ -14,9 +14,6 @@ import amd.rali.types as types
 
 import sys
 import numpy as np
-from enum import Enum
-import cv2
-import time
 
 
 class COCOPipeline(Pipeline):

--- a/rocAL/rocAL_pybind/example/coco_pipeline.py
+++ b/rocAL/rocAL_pybind/example/coco_pipeline.py
@@ -51,9 +51,10 @@ class COCOPipeline(Pipeline):
                                             output_layout=types.NCHW,
                                             crop=(crop, crop),
                                             image_type=types.RGB,
-                                            mean=[0.485 * 255, 0.456 *
-                                                  255, 0.406 * 255],
-                                            std=[0.229 * 255, 0.224 * 255, 0.225 * 255])
+                                            #mean=[0.485 * 255, 0.456 *255, 0.406 * 255],
+                                            #std=[0.229 * 255, 0.224 * 255, 0.225 * 255])
+                                            mean=[0, 0, 0],
+                                            std=[1, 1, 1])
         self.boxEncoder = ops.BoxEncoder(device=rali_device,
                                          criteria=0.5,
                                          anchors=default_boxes)
@@ -71,6 +72,7 @@ class COCOPipeline(Pipeline):
         contrast = self.rng1()
         brightness = self.rng2()
         hue = self.rng3()
+        
         self.jpegs, self.bb, self.labels = self.input(name="Reader")
         # images = self.decode(self.jpegs)
         # images = self.crop(images)
@@ -264,6 +266,7 @@ def draw_patches(img,idx, bboxes):
     import cv2
     image = img.detach().numpy()
     image = image.transpose([1,2,0])
+    image = cv2.cvtColor(image, cv2.COLOR_RGB2BGR )
  
     _,htot ,wtot = img.shape
     
@@ -274,7 +277,8 @@ def draw_patches(img,idx, bboxes):
         thickness = 2
         image = cv2.UMat(image).get()
         image = cv2.rectangle(image, (int(loc_[0]*wtot ),int( loc_[1] *htot)),(int((loc_[2] *wtot) ) ,int((loc_[3] *htot) )) , color, thickness)  
-        cv2.imwrite(str(idx)+"_"+"train"+".png", 255*image)
+        #cv2.imwrite(str(idx)+"_"+"train"+".png", 255*image)
+        cv2.imwrite(str(idx)+"_"+"train"+".png", image)
 
 def main():
     if len(sys.argv) < 5:

--- a/rocAL/rocAL_pybind/example/coco_pipeline.py
+++ b/rocAL/rocAL_pybind/example/coco_pipeline.py
@@ -24,7 +24,7 @@ class COCOPipeline(Pipeline):
         super(COCOPipeline, self).__init__(batch_size, num_threads,
                                            device_id, seed=12 + device_id, rali_cpu=rali_cpu)
         self.input = ops.COCOReader(
-            file_root=data_dir, annotations_file=ann_dir)
+            file_root=data_dir, annotations_file=ann_dir,random_shuffle=True)
         rali_device = 'cpu' if rali_cpu else 'gpu'
         decoder_device = 'cpu' if rali_cpu else 'mixed'
         # device_memory_padding = 211025920 if decoder_device == 'mixed' else 0
@@ -209,10 +209,8 @@ class RALICOCOIterator(object):
                 htot, wtot = 1, 1
                 bbox_sizes = []
                 i=0
-                for (l,t,w,h) in self.bb_2d_numpy:
+                for (l,t,r,b) in self.bb_2d_numpy:
                     
-                    r = l + w
-                    b = t + h
 
                     bbox_size = (l/wtot, t/htot, r/wtot, b/htot)
                     bbox_sizes.append(bbox_size)

--- a/rocAL/rocAL_pybind/example/coco_pipeline.py
+++ b/rocAL/rocAL_pybind/example/coco_pipeline.py
@@ -54,7 +54,6 @@ class COCOPipeline(Pipeline):
                                             output_layout=types.NCHW,
                                             crop=(crop, crop),
                                             image_type=types.RGB,
-                                            mirror=1,
                                             mean=[0.485 * 255, 0.456 *
                                                   255, 0.406 * 255],
                                             std=[0.229 * 255, 0.224 * 255, 0.225 * 255])
@@ -84,7 +83,7 @@ class COCOPipeline(Pipeline):
         images = self.res(images)
         images = self.twist(images, saturation=saturation,
                             contrast=contrast, brightness=brightness, hue=hue)
-        output = self.cmnp(images)
+        output = self.cmnp(images, mirror=coin)
         encoded_bboxes, encoded_labels = self.boxEncoder(bboxes, labels) # Encodes the bbox and labels ,input:"xywh" format output:"ltrb" format
         encoded_labels = self.cast(encoded_labels)
         return [output, encoded_bboxes, encoded_labels] #Encoded Bbox and labels output in "ltrb" format
@@ -277,8 +276,6 @@ def draw_patches(img,idx, bboxes):
         loc_ = [l, t ,r, b]
         color = (255, 0, 0)
         thickness = 2
-        start_point=(loc_[0] * wtot, loc_[1] * htot)
-        end_point= ((loc_[2] - loc_[0]) * wtot ,(loc_[3] - loc_[1]) * htot)
         image = cv2.UMat(image).get()
         image = cv2.rectangle(image, (int(loc_[0]*300 ),int( loc_[1] *300)),(int((loc_[2] *300) ) ,int((loc_[3] *300) )) , color, thickness)  
         cv2.imwrite(str(idx)+"_"+"train"+".png", 255*image)

--- a/rocAL/rocAL_pybind/example/coco_pipeline.py
+++ b/rocAL/rocAL_pybind/example/coco_pipeline.py
@@ -175,7 +175,7 @@ class RALICOCOIterator(object):
         self.img_size = np.zeros((self.bs * 2), dtype="int32")
         self.loader.GetImgSizes(self.img_size)
         print("Image sizes:", self.img_size)
-        img = torch.from_numpy(self.out)
+        #img = torch.from_numpy(self.out)
         count = 0
         sum_count = 0
         for i in range(self.bs):

--- a/rocAL/rocAL_pybind/example/coco_pipeline.py
+++ b/rocAL/rocAL_pybind/example/coco_pipeline.py
@@ -264,20 +264,19 @@ class RALICOCOIterator(object):
 
 def draw_patches(img,idx, bboxes):
     #image is expected as a tensor, bboxes as numpy
-    import matplotlib.pyplot as plt
-    import matplotlib.patches as patches
     import cv2
     image = img.detach().numpy()
     image = image.transpose([1,2,0])
  
-    htot, wtot,_ = img.shape
+    _,htot ,wtot = img.shape
+    
     for (l, t ,r,b) in bboxes:
         
         loc_ = [l, t ,r, b]
         color = (255, 0, 0)
         thickness = 2
         image = cv2.UMat(image).get()
-        image = cv2.rectangle(image, (int(loc_[0]*300 ),int( loc_[1] *300)),(int((loc_[2] *300) ) ,int((loc_[3] *300) )) , color, thickness)  
+        image = cv2.rectangle(image, (int(loc_[0]*wtot ),int( loc_[1] *htot)),(int((loc_[2] *wtot) ) ,int((loc_[3] *htot) )) , color, thickness)  
         cv2.imwrite(str(idx)+"_"+"train"+".png", 255*image)
 
 def main():

--- a/rocAL/rocAL_pybind/example/coco_pipeline.py
+++ b/rocAL/rocAL_pybind/example/coco_pipeline.py
@@ -274,9 +274,8 @@ def draw_patches(img,idx, bboxes):
     image = image.transpose([1,2,0])
  
     htot, wtot,_ = img.shape
-    for (l, t ,w , h) in bboxes:
-        r = l+ w
-        b = t + h
+    for (l, t ,r,b) in bboxes:
+        
         loc_ = [l, t ,r, b]
         color = (255, 0, 0)
         thickness = 2


### PR DESCRIPTION
@kiritigowda: This PR overrides PR513 update since it has more code fixes. Please please ignore PR 513 and merge this instead.
Add normalized co-ordinates for SSD bboxes. Fixes random_bbox_crop which caused accuracy drop in MLPerf training
