### PR TITLE
OpenVX HIP GPU backend - fix bugs for HarrisCorner3x3 kernels

### DIFF
--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -18145,7 +18145,7 @@ int agoKernel_NonMaxSupp_XY_ANY_3x3(AgoNode * node, AgoKernelCommand cmd)
         AgoData * oList = node->paramList[0];
         AgoData * iImg = node->paramList[1];
         if (HipExec_NonMaxSupp_XY_ANY_3x3(
-            node->hip_stream0, (vx_uint32)oList->u.arr.capacity, (ago_keypoint_xys_t *)(oList->hip_memory + oList->gpu_buffer_offset),
+            node->hip_stream0, (vx_uint32)oList->u.arr.capacity, oList->hip_memory, oList->gpu_buffer_offset,
             iImg->u.img.width, iImg->u.img.height, (vx_float32 *)(iImg->hip_memory + iImg->gpu_buffer_offset), iImg->u.img.stride_in_bytes)) {
 
             status = VX_FAILURE;

--- a/amd_openvx/openvx/hipvx/hip_host_decls.h
+++ b/amd_openvx/openvx/hipvx/hip_host_decls.h
@@ -896,8 +896,8 @@ int HipExec_HarrisScore_HVC_HG3_7x7(
         vx_float32 sensitivity, vx_float32 strength_threshold,
         vx_int32 border, vx_float32 normFactor);
 int HipExec_NonMaxSupp_XY_ANY_3x3(
-        hipStream_t stream, vx_uint32 capacityOfList, ago_keypoint_xys_t *pHipDstList,
-        vx_uint32 srcWidth, vx_uint32 srcHeight,
+        hipStream_t stream, vx_uint32 capacityOfList, vx_uint8 *pHipDstList,
+        vx_uint32 dstListOffset, vx_uint32 srcWidth, vx_uint32 srcHeight,
         vx_float32 *pHipSrcImage, vx_uint32 srcImageStrideInBytes);
 
 #endif //MIVISIONX_HIP_HOST_DECLS_H


### PR DESCRIPTION
- use a generic pointer to point to the shared memory
- use individual comparison when calculating harris scores
- don't pre-add the offset to the array containing the detected corners, as the first few bytes reserved for the total identified number of corners
- use atomicAdd instead of atomicInc
- use builtin __float_as_uint for presenting float as uint