### PR TITLE
amd_rpp - force gpu affinity to cpu for running without codegen

### DIFF
--- a/amd_openvx_extensions/amd_rpp/source/BrightnessbatchPD.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/BrightnessbatchPD.cpp
@@ -214,9 +214,14 @@ static vx_status VX_CALLBACK query_target_support(vx_graph graph, vx_node node,
 	AgoTargetAffinityInfo affinity;
 	vxQueryContext(context, VX_CONTEXT_ATTRIBUTE_AMD_AFFINITY,&affinity, sizeof(affinity));
 	if(affinity.device_type == AGO_TARGET_AFFINITY_GPU)
-    supported_target_affinity = AGO_TARGET_AFFINITY_GPU;
-  else
+    	supported_target_affinity = AGO_TARGET_AFFINITY_GPU;
+	else
+    	supported_target_affinity = AGO_TARGET_AFFINITY_CPU;
+
+	// hardcode the affinity to  CPU for OpenCL backend to avoid VerifyGraph failure since there is no codegen callback for amd_rpp nodes 	
+#if ENABLE_OPENCL
     supported_target_affinity = AGO_TARGET_AFFINITY_CPU;
+#endif		
   
   return VX_SUCCESS;
 }

--- a/amd_openvx_extensions/amd_rpp/source/ResizebatchPD.cpp
+++ b/amd_openvx_extensions/amd_rpp/source/ResizebatchPD.cpp
@@ -243,9 +243,14 @@ static vx_status VX_CALLBACK query_target_support(vx_graph graph, vx_node node,
 	AgoTargetAffinityInfo affinity;
 	vxQueryContext(context, VX_CONTEXT_ATTRIBUTE_AMD_AFFINITY,&affinity, sizeof(affinity));
 	if(affinity.device_type == AGO_TARGET_AFFINITY_GPU)
-    supported_target_affinity = AGO_TARGET_AFFINITY_GPU;
-  else
+    	supported_target_affinity = AGO_TARGET_AFFINITY_GPU;
+	else
+    	supported_target_affinity = AGO_TARGET_AFFINITY_CPU;
+
+	// hardcode the affinity to  CPU for OpenCL backend to avoid VerifyGraph failure since there is no codegen callback for amd_rpp nodes 	
+#if ENABLE_OPENCL
     supported_target_affinity = AGO_TARGET_AFFINITY_CPU;
+#endif		
   return VX_SUCCESS;
 }
 


### PR DESCRIPTION
Fixes bug where there is no output for certain test cases for OpenCL backend