### PR TITLE
VisionTest HIP GPU backend - Fix a segfault for opticalFlowLK gdf test

### DIFF
--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -15493,7 +15493,7 @@ int agoKernel_ScaleGaussianHalf_U8_U8_5x5(AgoNode * node, AgoKernelCommand cmd)
             node->hip_stream0, oImg->u.img.width, oImg->u.img.height,
             oImg->hip_memory + oImg->gpu_buffer_offset,oImg->u.img.stride_in_bytes,
             iImg->u.img.width, iImg->u.img.height,
-            iImg->hip_memory + iImg->gpu_buffer_offset, iImg->u.img.stride_in_bytes)) {
+            iImg->hip_memory + iImg->gpu_buffer_offset, iImg->u.img.stride_in_bytes, iImg->size)) {
             status = VX_FAILURE;
         }
     }

--- a/amd_openvx/openvx/hipvx/filter_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/filter_kernels.cpp
@@ -7060,7 +7060,7 @@ Hip_ScaleGaussianHalf_U8_U8_5x5(uint dstWidth, uint dstHeight,
     uchar *pDstImage, uint dstImageStrideInBytes,
     uint srcWidth, uint srcHeight,
     const uchar *pSrcImage, uint srcImageStrideInBytes,
-    uint dstWidthComp) {
+    int srcImageBufferSize, uint dstWidthComp) {
 
     __shared__ uchar lbuf[4760]; // 136x35 bytes
     int lx = hipThreadIdx_x;
@@ -7079,18 +7079,23 @@ Hip_ScaleGaussianHalf_U8_U8_5x5(uint dstWidth, uint dstHeight,
         *((uint2 *)(&lbuf[loffset])) = *((uint2 *)(&pSrcImage[srcIdx + goffset]));
         loffset += 16 * 136;
         goffset += 16 * srcStride;
-        *((uint2 *)(&lbuf[loffset])) = *((uint2 *)(&pSrcImage[srcIdx + goffset]));
+        int sidx = srcIdx + goffset;
+        if (sidx < srcImageBufferSize)
+            *((uint2 *)(&lbuf[loffset])) = *((uint2 *)(&pSrcImage[sidx]));
         if (ly < 3) {
             loffset += 16 * 136;
             goffset += 16 * srcStride;
-            *((uint2 *)(&lbuf[loffset])) = *((uint2 *)(&pSrcImage[srcIdx + goffset]));
+            sidx = srcIdx + goffset;
+            if (sidx < srcImageBufferSize)
+                *((uint2 *)(&lbuf[loffset])) = *((uint2 *)(&pSrcImage[sidx]));
         }
         uchar *lbufptr;
         lbufptr = lbuf + 128;
         goffset = -2 * srcStride + 124;
         int id = ly * 16 + lx;
-        if (id < 35) {
-            *((uint2 *)(&lbufptr[id * 136])) = *((uint2 *)(&pSrcImage[srcIdx + goffset + id * srcStride]));
+        sidx = srcIdx + goffset + id * srcStride;
+        if (id < 35 && sidx < srcImageBufferSize) {
+            *((uint2 *)(&lbufptr[id * 136])) = *((uint2 *)(&pSrcImage[sidx]));
         }
         __syncthreads();
     }
@@ -7288,7 +7293,7 @@ Hip_ScaleGaussianHalf_U8_U8_5x5(uint dstWidth, uint dstHeight,
 int HipExec_ScaleGaussianHalf_U8_U8_5x5(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeight,
     vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
     vx_uint32 srcWidth, vx_uint32 srcHeight,
-    const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes) {
+    const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes, vx_uint32 srcImageBufferSize) {
     int localThreads_x = 16;
     int localThreads_y = 16;
     int globalThreads_x = (dstWidth + 3) >> 2;
@@ -7298,7 +7303,7 @@ int HipExec_ScaleGaussianHalf_U8_U8_5x5(hipStream_t stream, vx_uint32 dstWidth, 
 
     hipLaunchKernelGGL(Hip_ScaleGaussianHalf_U8_U8_5x5, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
-                        srcWidth, srcHeight, (const uchar *)pHipSrcImage, srcImageStrideInBytes,
+                        srcWidth, srcHeight, (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         dstWidthComp);
 
     return VX_SUCCESS;

--- a/amd_openvx/openvx/hipvx/hip_host_decls.h
+++ b/amd_openvx/openvx/hipvx/hip_host_decls.h
@@ -682,7 +682,7 @@ int HipExec_ScaleGaussianHalf_U8_U8_5x5(
         hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeight,
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
         vx_uint32 srcWidth, vx_uint32 srcHeight,
-        const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes);
+        const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes, vx_uint32 srcImageBufferSize);
 
 // statistical_kernels
 


### PR DESCRIPTION
This PR addresses issue #541 for HIP GPU backend.