### PR TITLE
GCC 9 - CPU Warning Fix

### DIFF
--- a/amd_openvx/openvx/api/vx_api.cpp
+++ b/amd_openvx/openvx/api/vx_api.cpp
@@ -8505,7 +8505,7 @@ VX_API_ENTRY vx_object_array VX_API_CALL vxCreateObjectArray(vx_context context,
     if (agoIsValidContext(context) && agoIsValidReference(exemplar) && count > 0) {
         CAgoLock lock(context->cs);
         char desc_exemplar[512]; agoGetDescriptionFromData(context, desc_exemplar, (AgoData *)exemplar);
-        char desc[512]; sprintf(desc, "objectarray:" VX_FMT_SIZE ",[%s]", count, desc_exemplar);
+        char desc[1024]; sprintf(desc, "objectarray:" VX_FMT_SIZE ",[%s]", count, desc_exemplar);
         data = agoCreateDataFromDescription(context, NULL, desc, true);
         if (data) {
             agoGenerateDataName(context, "objectarray", data->name);
@@ -8718,7 +8718,7 @@ VX_API_ENTRY vx_object_array VX_API_CALL vxCreateVirtualObjectArray(vx_graph gra
     if (agoIsValidGraph(graph) && agoIsValidReference(exemplar) && count > 0) {
         CAgoLock lock(graph->cs);
         char desc_exemplar[512]; agoGetDescriptionFromData(graph->ref.context, desc_exemplar, (AgoData *)exemplar);
-        char desc[512]; sprintf(desc, "objectarray:" VX_FMT_SIZE ",[%s]", count, desc_exemplar);
+        char desc[1024]; sprintf(desc, "objectarray:" VX_FMT_SIZE ",[%s]", count, desc_exemplar);
         data = agoCreateDataFromDescription(graph->ref.context, NULL, desc, true);
         if (data) {
             agoGenerateVirtualDataName(graph, "objectarray", data->name);


### PR DESCRIPTION
* CMake Log 
```
-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- MIVisionX Version -- 2.0.0
-- MIVisionX Install Path -- /opt/rocm/mivisionx
-- MIVisionX Build Type -- Release
-- MIVisionX Backend set to OPENCL
-- MIVisionX Developer Options
--      -D NEURAL_NET=OFF [Turn OFF Neural Net Modules (default:ON)]
--      -D ROCAL=OFF [Turn OFF ROCAL Modules (default:ON)]
--      -D LOOM=OFF [Turn OFF LOOM Modules (default:ON)]
--      -D GPU_SUPPORT=OFF [Turn OFF GPU support (default:ON)]
--      -D BACKEND=HIP [select HIP for GPU backend (default:OPENCL)]
-- FindOpenCL failed to find: OpenCL
-- WARNING:OpenCL Not Found -- OpenVX built for CPU only
-- MIVisionX AMD_OpenVX -- OpenVX module added
-- FindAMDRPP failed to find: amd_rpp
-- FindOpenCL failed to find: OpenCL
-- WARNING:OpenCL/MIOpen/MIOpenGEMM Not Found -- amd_nn module excluded
-- WARNING:OpenCV Not Found -- amd_opencv module excluded
-- FindOpenCL failed to find: OpenCL
-- Found PkgConfig: /usr/bin/pkg-config (found version "0.29.1") 
-- Checking for module 'libavcodec'
--   Found libavcodec, version 57.107.100
-- Checking for module 'libavformat'
--   Found libavformat, version 57.83.100
-- Checking for module 'libavutil'
--   Found libavutil, version 55.78.100
-- FFMPEG   required min version - 4.0.4 Found:
-- AVCODEC  required min version - 58.18.100 Found:57.107.100
-- AVFORMAT required min version - 58.12.100 Found:57.83.100
-- AVUTIL   required min version - 56.14.100 Found:55.78.100
-- FindFFmpeg failed to find: FFMPEG
-- NOTE:GPU Support Not Found or Turned OFF -- runVX built for CPU only
-- MIVisionX Utilities -- runvx module added with CPU support
-- WARNING:OpenCL/FFMPEG Not Found -- runcl, loom_shell, & mv_deploy modules excluded
-- FindAMDRPP failed to find: amd_rpp
-- FFMPEG   required min version - 4.0.4 Found:
-- AVCODEC  required min version - 58.18.100 Found:57.107.100
-- AVFORMAT required min version - 58.12.100 Found:57.83.100
-- AVUTIL   required min version - 56.14.100 Found:55.78.100
-- FindFFmpeg failed to find: FFMPEG
-- FindOpenCL failed to find: OpenCL
-- rocAL library requires OpenCL for  BACKEND=OPENCL, Not Found 
-- rocAL library requires AMD's rpp library, Not Found 
-- WARNING: rocAL module excluded 
-- Configuring done
-- Generating done
-- Build files have been written to: /home/kiriti/develop/hip/build
```
* Warning
```
/home/kiriti/develop/hip/MIVisionX/amd_openvx/openvx/api/vx_api.cpp: In function ‘_vx_object_array* vxCreateObjectArray(vx_context, vx_reference, vx_size)’:
/home/kiriti/develop/hip/MIVisionX/amd_openvx/openvx/api/vx_api.cpp:8508:69: warning: ‘%s’ directive writing up to 511 bytes into a region of size between 478 and 497 [-Wformat-overflow=]
 8508 |         char desc[512]; sprintf(desc, "objectarray:" VX_FMT_SIZE ",[%s]", count, desc_exemplar);
      |                                                                     ^~           ~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:867,
                 from /home/kiriti/develop/hip/MIVisionX/amd_openvx/openvx/ago/ago_platform.h:37,
                 from /home/kiriti/develop/hip/MIVisionX/amd_openvx/openvx/ago/ago_internal.h:27,
                 from /home/kiriti/develop/hip/MIVisionX/amd_openvx/openvx/api/vx_api.cpp:24:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:36:34: note: ‘__builtin___sprintf_chk’ output between 17 and 547 bytes into a destination of size 512
   36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   37 |       __bos (__s), __fmt, __va_arg_pack ());
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/kiriti/develop/hip/MIVisionX/amd_openvx/openvx/api/vx_api.cpp: In function ‘_vx_object_array* vxCreateVirtualObjectArray(vx_graph, vx_reference, vx_size)’:
/home/kiriti/develop/hip/MIVisionX/amd_openvx/openvx/api/vx_api.cpp:8721:69: warning: ‘%s’ directive writing up to 511 bytes into a region of size between 478 and 497 [-Wformat-overflow=]
 8721 |         char desc[512]; sprintf(desc, "objectarray:" VX_FMT_SIZE ",[%s]", count, desc_exemplar);
      |                                                                     ^~           ~~~~~~~~~~~~~
In file included from /usr/include/stdio.h:867,
                 from /home/kiriti/develop/hip/MIVisionX/amd_openvx/openvx/ago/ago_platform.h:37,
                 from /home/kiriti/develop/hip/MIVisionX/amd_openvx/openvx/ago/ago_internal.h:27,
                 from /home/kiriti/develop/hip/MIVisionX/amd_openvx/openvx/api/vx_api.cpp:24:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:36:34: note: ‘__builtin___sprintf_chk’ output between 17 and 547 bytes into a destination of size 512
   36 |   return __builtin___sprintf_chk (__s, __USE_FORTIFY_LEVEL - 1,
      |          ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   37 |       __bos (__s), __fmt, __va_arg_pack ());
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

```

* Build Log
```
Scanning dependencies of target openvx
[  1%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_drama_merge.cpp.o
[  3%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_drama.cpp.o
[  7%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_drama_analyze.cpp.o
[  7%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_drama_divide.cpp.o
[  8%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_drama_remove.cpp.o
[ 10%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_arithmetic.cpp.o
[ 12%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_drama_alloc.cpp.o
[ 14%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu.cpp.o
[ 16%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_canny.cpp.o
[ 17%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_ch_extract_combine.cpp.o
[ 19%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_color_convert.cpp.o
[ 21%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_fast_corners.cpp.o
[ 23%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_filter.cpp.o
[ 25%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_geometric.cpp.o
[ 26%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_generic_functions.cpp.o
[ 28%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_harris.cpp.o
[ 30%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_histogram.cpp.o
[ 32%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_logical.cpp.o
[ 33%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_opticalflow.cpp.o
[ 35%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_pyramid.cpp.o
[ 37%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_gpu_common.cpp.o
[ 39%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_gpu_conversion.cpp.o
[ 41%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_gpu_corners.cpp.o
[ 42%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_gpu_linear_filter.cpp.o
[ 44%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_gpu_special_filters.cpp.o
[ 46%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_interface.cpp.o
[ 48%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_kernel_api.cpp.o
[ 50%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_kernel_list.cpp.o
[ 51%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_platform.cpp.o
[ 53%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_util.cpp.o
[ 55%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_util_opencl.cpp.o
[ 57%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_util_hip.cpp.o
[ 58%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/api/vxu.cpp.o
[ 60%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/api/vx_api.cpp.o
[ 62%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/api/vx_nodes.cpp.o
[ 64%] Linking CXX shared library ../../lib/libopenvx.so
[ 64%] Built target openvx
Scanning dependencies of target runvx
Scanning dependencies of target vxu
[ 66%] Building CXX object amd_openvx/openvx/CMakeFiles/vxu.dir/api/vxu.cpp.o
[ 67%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxEngineUtil.cpp.o
[ 71%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxConvolution.cpp.o
[ 71%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxDistribution.cpp.o
[ 73%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxEngine.cpp.o
[ 75%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxImage.cpp.o
[ 78%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/runvx.cpp.o
[ 78%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxArray.cpp.o
[ 80%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxLUT.cpp.o
[ 82%] Linking CXX shared library ../../lib/libvxu.so
[ 82%] Built target vxu
[ 83%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxMatrix.cpp.o
[ 87%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxParamHelper.cpp.o
[ 87%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxParameter.cpp.o
[ 89%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxPyramid.cpp.o
[ 91%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxRemap.cpp.o
[ 92%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxScalar.cpp.o
[ 94%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxThreshold.cpp.o
[ 96%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxTensor.cpp.o
[ 98%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxUtils.cpp.o
[100%] Linking CXX executable ../../bin/runvx
[100%] Built target runvx
```