### PR TITLE
rocal_pybind - fix for package link error

### DIFF
--- a/rocAL/rocAL_pybind/CMakeLists.txt
+++ b/rocAL/rocAL_pybind/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 if(${BUILD_RALI_PYBIND})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
 
-    link_directories(${ROCM_PATH}/rpp/lib)
+    link_directories(${ROCM_PATH}/rpp/lib ${ROCM_PATH}/mivisionx/lib)
 
     include_directories(../rocAL/include/
                         third_party_lib/


### PR DESCRIPTION
Fixes link issue where library is not found.