### PR TITLE
rocAL Pybind - Temp Fix

### DIFF
--- a/rocAL/rocAL_pybind/CMakeLists.txt
+++ b/rocAL/rocAL_pybind/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 if(${BUILD_RALI_PYBIND})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3")
 
-    link_directories(${ROCM_PATH}/rpp/lib ${CMAKE_INSTALL_PREFIX}/lib)
+    link_directories(${ROCM_PATH}/rpp/lib ${ROCM_PATH}/mivisionx/lib)
 
     include_directories(../rocAL/include/
                         third_party_lib/


### PR DESCRIPTION
Fix rocAL Pybind 

* Top level CMakeLists not used in run.sh
* Link path set in top level CMake needs adding the run.sh to clean build pybind

This PR is a temp fix to allow existing tests to work