### PR TITLE
Bug Fix - topK layer

### DIFF
--- a/amd_openvx_extensions/amd_nn/src/topk_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/topk_layer.cpp
@@ -211,7 +211,6 @@ static vx_status VX_CALLBACK uninitializeTopK(vx_node node, const vx_reference *
 	ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
 	if(data)
 	{
-		free(data->x_tensor_buffer);
 		delete data;
 	}
 


### PR DESCRIPTION
Issue seen by @asalmanp while running runvx for topK layer is fixed by this PR
```
free(): invalid next size (fast)
Aborted (core dumped)
```

