### PR TITLE
Issue 558 -  vxMapRemapPatch.MapRandomRemap Random Failure Fix

### DIFF
--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -1868,7 +1868,9 @@ int ovxKernel_HarrisCorners(AgoNode * node, AgoKernelCommand cmd)
     //       use VX_KERNEL_AMD_HARRIS_SCORE_* kernels to compute Vc
     //       use VX_KERNEL_AMD_HARRIS_MERGE_SORT_AND_PICK_XY_HVC kernel for final step
     //       disable buffer merging for HarrisCorners
-    agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1");
+    if(node->attr_affinity.device_type == AGO_KERNEL_FLAG_DEVICE_GPU){
+        agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1");
+    }
     vx_status status = AGO_ERROR_KERNEL_NOT_IMPLEMENTED;
     if (cmd == ago_kernel_cmd_execute) {
         // TBD: not implemented yet

--- a/amd_openvx/openvx/ago/ago_platform.cpp
+++ b/amd_openvx/openvx/ago/ago_platform.cpp
@@ -94,6 +94,15 @@ bool agoSetEnvironmentVariable(const char * name, const char * value)
 #endif
 }
 
+bool agoUnsetEnvironmentVariable(const char * name)
+{
+#if _WIN32
+    return SetEnvironmentVariableA(name, null);
+#else
+    return !(unsetenv(name));
+#endif
+}
+
 ago_module agoOpenModule(const char * libFileName)
 {
 #if _WIN32

--- a/amd_openvx/openvx/ago/ago_platform.h
+++ b/amd_openvx/openvx/ago/ago_platform.h
@@ -136,6 +136,7 @@ int64_t    agoGetClockCounter();
 int64_t    agoGetClockFrequency();
 bool       agoGetEnvironmentVariable(const char * name, char * value, size_t valueSize); // returns true if success
 bool       agoSetEnvironmentVariable(const char * name, const char * value); // returns true if success
+bool       agoUnsetEnvironmentVariable(const char * name); // returns true if success
 ago_module agoOpenModule(const char * libFileName);
 void *     agoGetFunctionAddress(ago_module module, const char * functionName);
 void       agoCloseModule(ago_module module);


### PR DESCRIPTION
* Set agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1") harrisCorners - Only if Target Set to GPU
* Need to Unset the Variable after HarrisCorners GPU is complete