### PR TITLE
OpenVX GPU backend - fix a regression for HarrisCorner node introduced by PR#596

### DIFF
--- a/amd_openvx/openvx/ago/ago_drama_alloc.cpp
+++ b/amd_openvx/openvx/ago/ago_drama_alloc.cpp
@@ -334,6 +334,17 @@ int agoGpuAllocBuffers(AgoGraph * graph)
             }
         }
     }
+
+   // The AGO_BUFFER_MERGE_FLAGS is set for HarrisCorner as buffer merging is not working for this node.
+   // At the end of the GPU buffer allocation routine, unset the AGO_BUFFER_MERGE_FLAGS environment variable
+   // if the HarrisCorner is present in the graph.
+    for (AgoNode * node = graph->nodeList.head; node; node = node->next) {
+        if (strstr(node->akernel->name, "Harris") != NULL) {
+            agoUnsetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS");
+            break;
+        }
+    }
+
     return 0;
 }
 

--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -1868,9 +1868,7 @@ int ovxKernel_HarrisCorners(AgoNode * node, AgoKernelCommand cmd)
     //       use VX_KERNEL_AMD_HARRIS_SCORE_* kernels to compute Vc
     //       use VX_KERNEL_AMD_HARRIS_MERGE_SORT_AND_PICK_XY_HVC kernel for final step
     //       disable buffer merging for HarrisCorners
-    if(node->attr_affinity.device_type == AGO_KERNEL_FLAG_DEVICE_GPU){
-        agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1");
-    }
+    agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1");
     vx_status status = AGO_ERROR_KERNEL_NOT_IMPLEMENTED;
     if (cmd == ago_kernel_cmd_execute) {
         // TBD: not implemented yet

--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -1867,13 +1867,15 @@ int ovxKernel_HarrisCorners(AgoNode * node, AgoKernelCommand cmd)
     // INFO: use VX_KERNEL_AMD_HARRIS_SOBEL_* kernels to compute Gx^2, Gx*Gy, Gy^2
     //       use VX_KERNEL_AMD_HARRIS_SCORE_* kernels to compute Vc
     //       use VX_KERNEL_AMD_HARRIS_MERGE_SORT_AND_PICK_XY_HVC kernel for final step
-    //       disable buffer merging for HarrisCorners
+    //       disable buffer merging for HarrisCorners temporarily as a workaround
+#if ENABLE_OPENCL || ENABLE_HIP
     char textBuffer[1024];
     if (agoGetEnvironmentVariable("AGO_DEFAULT_TARGET", textBuffer, sizeof(textBuffer))) {
         if (!strcmp(textBuffer, "GPU")) {
             agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1");
         }
     }
+#endif
     vx_status status = AGO_ERROR_KERNEL_NOT_IMPLEMENTED;
     if (cmd == ago_kernel_cmd_execute) {
         // TBD: not implemented yet

--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -1867,15 +1867,6 @@ int ovxKernel_HarrisCorners(AgoNode * node, AgoKernelCommand cmd)
     // INFO: use VX_KERNEL_AMD_HARRIS_SOBEL_* kernels to compute Gx^2, Gx*Gy, Gy^2
     //       use VX_KERNEL_AMD_HARRIS_SCORE_* kernels to compute Vc
     //       use VX_KERNEL_AMD_HARRIS_MERGE_SORT_AND_PICK_XY_HVC kernel for final step
-    //       disable buffer merging for HarrisCorners temporarily as a workaround
-#if ENABLE_OPENCL || ENABLE_HIP
-    char textBuffer[1024];
-    if (agoGetEnvironmentVariable("AGO_DEFAULT_TARGET", textBuffer, sizeof(textBuffer))) {
-        if (!strcmp(textBuffer, "GPU")) {
-            agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1");
-        }
-    }
-#endif
     vx_status status = AGO_ERROR_KERNEL_NOT_IMPLEMENTED;
     if (cmd == ago_kernel_cmd_execute) {
         // TBD: not implemented yet
@@ -1900,6 +1891,15 @@ int ovxKernel_HarrisCorners(AgoNode * node, AgoKernelCommand cmd)
         node->metaList[6].data.u.arr.capacity = 0;
         node->metaList[7].data.u.scalar.type = VX_TYPE_SIZE;
         status = VX_SUCCESS;
+        //disable buffer merging for HarrisCorners on both OCL and HIP GPU backends temporarily as a workaround
+#if ENABLE_OPENCL || ENABLE_HIP
+    char textBuffer[1024];
+    if (agoGetEnvironmentVariable("AGO_DEFAULT_TARGET", textBuffer, sizeof(textBuffer))) {
+        if (!strcmp(textBuffer, "GPU")) {
+            agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1");
+        }
+    }
+#endif
     }
     else if (cmd == ago_kernel_cmd_initialize || cmd == ago_kernel_cmd_shutdown) {
         status = VX_SUCCESS;

--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -1868,7 +1868,12 @@ int ovxKernel_HarrisCorners(AgoNode * node, AgoKernelCommand cmd)
     //       use VX_KERNEL_AMD_HARRIS_SCORE_* kernels to compute Vc
     //       use VX_KERNEL_AMD_HARRIS_MERGE_SORT_AND_PICK_XY_HVC kernel for final step
     //       disable buffer merging for HarrisCorners
-    agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1");
+    char textBuffer[1024];
+    if (agoGetEnvironmentVariable("AGO_DEFAULT_TARGET", textBuffer, sizeof(textBuffer))) {
+        if (!strcmp(textBuffer, "GPU")) {
+            agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1");
+        }
+    }
     vx_status status = AGO_ERROR_KERNEL_NOT_IMPLEMENTED;
     if (cmd == ago_kernel_cmd_execute) {
         // TBD: not implemented yet

--- a/amd_openvx/openvx/api/vx_api.cpp
+++ b/amd_openvx/openvx/api/vx_api.cpp
@@ -2905,6 +2905,15 @@ VX_API_ENTRY vx_status VX_API_CALL vxVerifyGraph(vx_graph graph)
             agoWriteGraph(graph, NULL, 0, stdout, "*INPUT*");
         }
 
+        // set the AGO_DEFAULT_TARGET if it is not set by the user
+        if (!agoGetEnvironmentVariable("AGO_DEFAULT_TARGET", textBuffer, sizeof(textBuffer))) {
+#if ENABLE_OPENCL || ENABLE_HIP
+            agoSetEnvironmentVariable("AGO_DEFAULT_TARGET", "GPU");
+#else
+            agoSetEnvironmentVariable("AGO_DEFAULT_TARGET", "CPU");
+#endif
+    }
+
         // verify graph per OpenVX specification
         status = agoVerifyGraph(graph);
         if (status == VX_SUCCESS) {


### PR DESCRIPTION
PR#596 introduced a regression for HarrisCorner and it is causing a segfault for this node. PR#596 added an extra if check to set AGO_BUFFER_MERGE_FLAGS if the device_type is GPU but the issue is that the device_type is not initialized when we reach the ovxKernel_HarrisCorners function. 

This PR removes this extra if and it makes sure that the AGO_BUFFER_MERGE_FLAGS is unset if HarrisCorner is used in the graph.