### PR TITLE
HarrisCorners - Buffer Merge Turn Off

### DIFF
--- a/amd_openvx/openvx/ago/ago_drama_alloc.cpp
+++ b/amd_openvx/openvx/ago/ago_drama_alloc.cpp
@@ -334,6 +334,19 @@ int agoGpuAllocBuffers(AgoGraph * graph)
             }
         }
     }
+
+// TBD -- The AGO_BUFFER_MERGE_FLAGS is set for HarrisCorner as buffer merging is not working for this node.
+// At the end of the GPU buffer allocation routine, unset the AGO_BUFFER_MERGE_FLAGS environment variable
+// if the HarrisCorner is present in the graph - for OpenCL Work Flow.
+#if ENABLE_OPENCL
+    for (AgoNode * node = graph->nodeList.head; node; node = node->next) {
+        if (strstr(node->akernel->name, "Harris") != NULL) {
+            agoUnsetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS");
+            break;
+        }
+    }
+#endif
+
     return 0;
 }
 
@@ -569,6 +582,16 @@ static int agoOptimizeDramaAllocSetDefaultTargets(AgoGraph * agraph)
         else if (!strcmp(textBuffer, "CPU")) {
             default_target = AGO_KERNEL_FLAG_DEVICE_CPU;
         }
+// TBD -- As HarrisCorners work around - set envr variable if not set
+#if ENABLE_OPENCL || ENABLE_HIP
+        else{
+            agoSetEnvironmentVariable("AGO_DEFAULT_TARGET", "GPU");
+        }
+#else
+        else{
+            agoSetEnvironmentVariable("AGO_DEFAULT_TARGET", "CPU");
+        }
+#endif
     }
 
     for (AgoNode * node = agraph->nodeList.head; node; node = node->next) {

--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -1867,10 +1867,17 @@ int ovxKernel_HarrisCorners(AgoNode * node, AgoKernelCommand cmd)
     // INFO: use VX_KERNEL_AMD_HARRIS_SOBEL_* kernels to compute Gx^2, Gx*Gy, Gy^2
     //       use VX_KERNEL_AMD_HARRIS_SCORE_* kernels to compute Vc
     //       use VX_KERNEL_AMD_HARRIS_MERGE_SORT_AND_PICK_XY_HVC kernel for final step
-    //       disable buffer merging for HarrisCorners
-    if(node->attr_affinity.device_type == AGO_KERNEL_FLAG_DEVICE_GPU){
-        agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1");
+
+// TBD -- disable buffer merging for HarrisCorners as buffer merging is not working for this node in OpenCL Flow
+#if ENABLE_OPENCL
+    char textBuffer[1024];
+    if (agoGetEnvironmentVariable("AGO_DEFAULT_TARGET", textBuffer, sizeof(textBuffer))) {
+        if (!strcmp(textBuffer, "GPU")) {
+            agoSetEnvironmentVariable("AGO_BUFFER_MERGE_FLAGS", "1");
+        }
     }
+#endif
+
     vx_status status = AGO_ERROR_KERNEL_NOT_IMPLEMENTED;
     if (cmd == ago_kernel_cmd_execute) {
         // TBD: not implemented yet


### PR DESCRIPTION
As a part of the Buffer Merge Shutoff for HarrisCorners

* Set Environmental Variable - AGO_DEFAULT_TARGET to CPU/GPU if not set
* Check ENVR variable AGO_DEFAULT_TARGET - if set to GPU in OpenCL - turn off Buffer Merge - AGO_BUFFER_MERGE_FLAGS
* If OpenCL Flow - UnSet ENVR Variable at the end of the run - AGO_BUFFER_MERGE_FLAGS