### PR TITLE
Issue #458 Fix - GNU 9.3.0: Warnings & Error Handling 

### DIFF
--- a/amd_openvx/openvx/ago/ago_internal.h
+++ b/amd_openvx/openvx/ago/ago_internal.h
@@ -609,7 +609,7 @@ struct AgoNode {
     struct { bool enable; int paramIndexScalar; int paramIndexArray; } gpu_scalar_array_output_sync;
 #if ENABLE_OPENCL
     vx_uint32 opencl_type;
-    char opencl_name[VX_MAX_KERNEL_NAME];
+    char opencl_name[VX_MAX_KERNEL_NAME+8];
     std::string opencl_code;
     std::string opencl_build_options;
     vx_uint32 opencl_param_mem2reg_mask;

--- a/amd_openvx_extensions/amd_loomsl/live_stitch_api.cpp
+++ b/amd_openvx_extensions/amd_loomsl/live_stitch_api.cpp
@@ -3573,7 +3573,10 @@ LIVE_STITCH_API_ENTRY vx_status VX_API_CALL lsExportConfiguration(ls_context sti
 			ls_printf("ERROR: lsExportConfiguration: gdf: requires fileName extension to be .gdf\n");
 			return VX_ERROR_INVALID_PARAMETERS;
 		}
-		char fileNamePrefixForTables[1024] = { 0 }; strncpy(fileNamePrefixForTables, fileName, strlen(fileName) - 4);
+		char fileNamePrefixForTables[1024] = { 0 };
+		std::string tableName = fileName;
+		tableName.erase(tableName.find_last_of("."), std::string::npos);
+		strncpy(fileNamePrefixForTables, tableName.c_str(), strlen(fileNamePrefixForTables));
 		FILE * fp = fopen(fileName, "w");
 		if (!fp) {
 			ls_printf("ERROR: lsExportConfiguration: unable to create: %s\n", fileName);

--- a/amd_openvx_extensions/amd_nn/src/kernels.cpp
+++ b/amd_openvx_extensions/amd_nn/src/kernels.cpp
@@ -89,7 +89,7 @@ int getEnvironmentVariable(const char * name, char * value, size_t valueSize)
 #else
     const char * text = getenv(name);
     if (text) {
-        strncpy(value, text, strlen(text)+1);
+        strncpy(value, text, valueSize);
         value[strlen(text)+1] = '\0';
         if(isdigit(value[0]) != 0)
             return atoi(value);


### PR DESCRIPTION
Issue #458 Fix
```
Scanning dependencies of target runcl
Scanning dependencies of target openvx
[  1%] Building CXX object utilities/runcl/CMakeFiles/runcl.dir/runcl.cpp.o
[  2%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_drama_divide.cpp.o
[  3%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu.cpp.o
[  5%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_drama_merge.cpp.o
[  6%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_drama_analyze.cpp.o
[  7%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_drama.cpp.o
[  8%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_drama_alloc.cpp.o
[ 10%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_drama_remove.cpp.o
[ 11%] Linking CXX executable ../../bin/runcl
[ 12%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_arithmetic.cpp.o
[ 13%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_canny.cpp.o
[ 13%] Built target runcl
[ 15%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_ch_extract_combine.cpp.o
[ 16%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_color_convert.cpp.o
[ 17%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_fast_corners.cpp.o
[ 18%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_filter.cpp.o
[ 20%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_geometric.cpp.o
[ 21%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_generic_functions.cpp.o
[ 22%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_harris.cpp.o
[ 23%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_histogram.cpp.o
[ 25%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_logical.cpp.o
[ 26%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_opticalflow.cpp.o
[ 27%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_cpu_pyramid.cpp.o
[ 28%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_gpu_common.cpp.o
[ 30%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_gpu_conversion.cpp.o
[ 31%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_gpu_corners.cpp.o
[ 32%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_gpu_linear_filter.cpp.o
[ 33%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_haf_gpu_special_filters.cpp.o
[ 35%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_interface.cpp.o
[ 36%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_kernel_api.cpp.o
[ 37%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_kernel_list.cpp.o
[ 38%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_platform.cpp.o
[ 40%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_util.cpp.o
[ 41%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_util_opencl.cpp.o
[ 42%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/ago/ago_util_hip.cpp.o
[ 43%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/api/vxu.cpp.o
[ 45%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/api/vx_api.cpp.o
[ 46%] Building CXX object amd_openvx/openvx/CMakeFiles/openvx.dir/api/vx_nodes.cpp.o
[ 47%] Linking CXX shared library ../../lib/libopenvx.so
[ 47%] Built target openvx
Scanning dependencies of target vxu
Scanning dependencies of target vx_loomsl
Scanning dependencies of target runvx
[ 48%] Building CXX object amd_openvx/openvx/CMakeFiles/vxu.dir/api/vxu.cpp.o
[ 51%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxConvolution.cpp.o
[ 51%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxEngine.cpp.o
[ 52%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/chroma_key.cpp.o
[ 55%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxArray.cpp.o
[ 55%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/runvx.cpp.o
[ 56%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/alpha_blend.cpp.o
[ 57%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxDistribution.cpp.o
[ 58%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxEngineUtil.cpp.o
[ 60%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxImage.cpp.o
[ 61%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxLUT.cpp.o
[ 62%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxMatrix.cpp.o
[ 63%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/color_convert.cpp.o
[ 65%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxParameter.cpp.o
[ 66%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/exp_comp.cpp.o
[ 67%] Linking CXX shared library ../../lib/libvxu.so
[ 67%] Built target vxu
[ 70%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxParamHelper.cpp.o
[ 70%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/exposure_compensation.cpp.o
[ 71%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxPyramid.cpp.o
[ 72%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxRemap.cpp.o
[ 73%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/kernels.cpp.o
[ 75%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxScalar.cpp.o
[ 76%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxThreshold.cpp.o
[ 77%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/lens_distortion_remap.cpp.o
[ 78%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/merge.cpp.o
[ 80%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxTensor.cpp.o
[ 81%] Building CXX object utilities/runvx/CMakeFiles/runvx.dir/vxUtils.cpp.o
[ 82%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/multiband_blender.cpp.o
[ 83%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/noise_filter.cpp.o
[ 85%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/pyramid_scale.cpp.o
[ 86%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/seam_find.cpp.o
[ 87%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/warp.cpp.o
[ 88%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/warp_eqr_to_aze.cpp.o
[ 90%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/kernels/initialize_setup_tables.cpp.o
[ 91%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/live_stitch_api.cpp.o
[ 92%] Building CXX object amd_openvx_extensions/amd_loomsl/CMakeFiles/vx_loomsl.dir/profiler.cpp.o
[ 93%] Linking CXX executable ../../bin/runvx
[ 93%] Built target runvx
[ 95%] Linking CXX shared library ../../lib/libvx_loomsl.so
[ 95%] Built target vx_loomsl
Scanning dependencies of target loom_shell
[ 96%] Building CXX object utilities/loom_shell/CMakeFiles/loom_shell.dir/loom_shell_util.cpp.o
[ 97%] Building CXX object utilities/loom_shell/CMakeFiles/loom_shell.dir/loom_shell.cpp.o
[ 98%] Building CXX object utilities/loom_shell/CMakeFiles/loom_shell.dir/help.cpp.o
[100%] Linking CXX executable ../../bin/loom_shell
[100%] Built target loom_shell
```