### PR TITLE
Neural Network Extension, HIP GPU backend - add support for layers that use MIOpen

### DIFF
--- a/amd_openvx_extensions/amd_nn/nn_hip/nn_hip_host_decls.h
+++ b/amd_openvx_extensions/amd_nn/nn_hip/nn_hip_host_decls.h
@@ -23,6 +23,7 @@ THE SOFTWARE.
 #ifndef NN_HIP_HOST_DECLS_H
 #define NN_HIP_HOST_DECLS_H
 #include "hip/hip_runtime.h"
+#include "hip/hip_fp16.h"
 #include <VX/vx.h>
 
 int HipExec_Gather_layer(hipStream_t stream, dim3 globalThreads, dim3 localThreads, vx_enum type, unsigned char* in, uint in_offset,
@@ -41,5 +42,8 @@ int HipExec_image_to_tensor_layer(hipStream_t stream, vx_df_image format, vx_enu
 
 int HipExec_tensor_to_image_layer(hipStream_t stream, vx_df_image format, vx_enum type, uint width, uint height, uint N, unsigned char* in,
     uint in_offset, uint4 in_stride, unsigned char* out, uint out_offset, uint out_stride, float sc1, float sc2, uint reverse_channel_order);
+
+int HipExec_copy(hipStream_t stream, vx_enum type, unsigned char* inp, unsigned char* out, uint width, uint height, uint ldi, uint i_offset,
+    uint ldc, uint c_offset, bool tI);
 
 #endif //NN_HIP_HOST_DECLS_H

--- a/amd_openvx_extensions/amd_nn/src/batch_normalization_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/batch_normalization_layer.cpp
@@ -25,15 +25,28 @@ THE SOFTWARE.
 struct BatchNormLayerLocalData {
     NeuralNetworkCommonHandle * handle;
     miopenTensorDescriptor_t input_desc;
+#if ENABLE_OPENCL
     cl_mem input_mem;
+#elif ENABLE_HIP
+    vx_uint8 *input_mem;
+#endif
     miopenTensorDescriptor_t output_desc;
     miopenDataType_t data_type;          // data_type for the kernel
+#if ENABLE_OPENCL
     cl_mem output_mem;
     cl_mem workspace;
+#elif ENABLE_HIP
+    vx_uint8 *output_mem;
+    vx_uint8 *workspace;
+#endif
     size_t workspace_size;
     float alpha, beta, eps;
     miopenTensorDescriptor_t bnScaleBiasMeanVarDesc;
+#if ENABLE_OPENCL
     cl_mem bnScale, bnBias, bnMean, bnVariance;
+#elif ENABLE_HIP
+    vx_uint8 *bnScale, *bnBias, *bnMean, *bnVariance;
+#endif
 };
 
 static vx_status VX_CALLBACK validateBatchNormalizationLayer(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])
@@ -109,8 +122,13 @@ PROFILER_START(VX_NN, Batch_Normalization_Layer)
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     miopenHandle_t miopenHandle = data->handle->miopen_handle;
 
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[6], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[6], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
     // miopen batch norm inference.
     ERROR_CHECK_MIOPEN_STATUS(miopenBatchNormalizationForwardInference(miopenHandle, miopenBNSpatial, &data->alpha, &data->beta, data->input_desc, data->input_mem,
@@ -149,6 +167,7 @@ static vx_status VX_CALLBACK initializeBatchNormalizationLayer(vx_node node, con
 
     data->alpha = 1; data->beta = 0;
 
+#if ENABLE_OPENCL
     // input and output memory.
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->bnMean, sizeof(data->bnMean)));
@@ -163,6 +182,7 @@ static vx_status VX_CALLBACK initializeBatchNormalizationLayer(vx_node node, con
         ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_OPENCL_CONTEXT, &context, sizeof(context)));
         cl_float pattern = 0; cl_int err = 0;
         data->bnBias = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(float)*input_dims[2], NULL, &err);
+
         if (err) return VX_FAILURE;
         if (data->data_type == miopenFloat)
             err = clEnqueueFillBuffer(data->handle->cmdq, data->bnBias, &pattern, sizeof(cl_float), 0, input_dims[2], 0, NULL, NULL);
@@ -172,6 +192,40 @@ static vx_status VX_CALLBACK initializeBatchNormalizationLayer(vx_node node, con
         if (err) return VX_FAILURE;
     }
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[6], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    // input and output memory.
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->bnMean, sizeof(data->bnMean)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &data->bnVariance, sizeof(data->bnVariance)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_HIP, &data->bnScale, sizeof(data->bnScale)));
+    if(parameters[4]) {
+        ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[4], VX_TENSOR_BUFFER_HIP, &data->bnBias, sizeof(data->bnBias)));
+    } else {
+        vx_context vxContext = vxGetContext((vx_reference)node);
+        int hip_device = -1;
+        ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_HIP_DEVICE, &hip_device, sizeof(hip_device)));
+        if (hip_device < 0) {
+            return VX_FAILURE;
+        }
+        hipError_t errcode_ret = hipSuccess;
+        errcode_ret = hipSetDevice(hip_device);
+        if (errcode_ret != hipSuccess) {
+            return VX_FAILURE;
+        }
+
+        errcode_ret = hipMalloc(&data->bnBias, sizeof(float)*input_dims[2]);
+        if (errcode_ret != hipSuccess) {
+            return VX_FAILURE;
+        }
+
+        errcode_ret = hipMemset(data->bnBias, 0, input_dims[2]);
+        if (errcode_ret != hipSuccess) {
+            return VX_FAILURE;
+        }
+    }
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[6], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+
+#endif
 
     data->eps = 0.00001;
     ERROR_CHECK_STATUS(vxCopyScalar((vx_scalar)parameters[5], &data->eps, VX_READ_ONLY, VX_MEMORY_TYPE_HOST));
@@ -196,8 +250,15 @@ static vx_status VX_CALLBACK uninitializeBatchNormalizationLayer(vx_node node, c
         ERROR_CHECK_MIOPEN_STATUS(miopenDestroyTensorDescriptor(data->bnScaleBiasMeanVarDesc));
         if(!parameters[4]){
             if(data->bnBias) {
+#if ENABLE_OPENCL
                 cl_int err = clReleaseMemObject(data->bnBias);
                 if (err) return VX_FAILURE;
+#elif ENABLE_HIP
+            hipError_t errcode_ret = hipFree((void *)data->bnBias);
+            if (errcode_ret != hipSuccess) {
+                return VX_FAILURE;
+            }
+#endif
             }
         }
         ERROR_CHECK_STATUS(releaseGraphHandle(node, data->handle));

--- a/amd_openvx_extensions/amd_nn/src/batch_normalization_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/batch_normalization_layer.cpp
@@ -208,11 +208,6 @@ static vx_status VX_CALLBACK initializeBatchNormalizationLayer(vx_node node, con
             return VX_FAILURE;
         }
         hipError_t errcode_ret = hipSuccess;
-        errcode_ret = hipSetDevice(hip_device);
-        if (errcode_ret != hipSuccess) {
-            return VX_FAILURE;
-        }
-
         errcode_ret = hipMalloc(&data->bnBias, sizeof(float)*input_dims[2]);
         if (errcode_ret != hipSuccess) {
             return VX_FAILURE;

--- a/amd_openvx_extensions/amd_nn/src/batch_normalization_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/batch_normalization_layer.cpp
@@ -168,13 +168,13 @@ static vx_status VX_CALLBACK initializeBatchNormalizationLayer(vx_node node, con
         cl_context context;
         ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_OPENCL_CONTEXT, &context, sizeof(context)));
         cl_float pattern = 0; cl_int err = 0;
-        *(cl_mem *)data->bnBias = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(float)*input_dims[2], NULL, &err);
+        data->bnBias = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(float)*input_dims[2], NULL, &err);
 
         if (err) return VX_FAILURE;
         if (data->data_type == miopenFloat)
-            err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->bnBias, &pattern, sizeof(cl_float), 0, input_dims[2], 0, NULL, NULL);
+            err = clEnqueueFillBuffer(data->handle->cmdq, (cl_mem)data->bnBias, &pattern, sizeof(cl_float), 0, input_dims[2], 0, NULL, NULL);
         else
-            err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->bnBias, &pattern, sizeof(cl_half), 0, input_dims[2], 0, NULL, NULL);
+            err = clEnqueueFillBuffer(data->handle->cmdq, (cl_mem)data->bnBias, &pattern, sizeof(cl_half), 0, input_dims[2], 0, NULL, NULL);
 
         if (err) return VX_FAILURE;
     }
@@ -233,7 +233,7 @@ static vx_status VX_CALLBACK uninitializeBatchNormalizationLayer(vx_node node, c
         if(!parameters[4]){
             if(data->bnBias) {
 #if ENABLE_OPENCL
-                cl_int err = clReleaseMemObject(*(cl_mem *)data->bnBias);
+                cl_int err = clReleaseMemObject((cl_mem)data->bnBias);
                 if (err) return VX_FAILURE;
 #elif ENABLE_HIP
             hipError_t errcode_ret = hipFree(data->bnBias);

--- a/amd_openvx_extensions/amd_nn/src/cast_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/cast_layer.cpp
@@ -260,17 +260,33 @@ static vx_status VX_CALLBACK host_kernel(vx_node node, const vx_reference * para
     globalThreads.y = input_dims[1];
     globalThreads.z = input_dims[2] * input_dims[3];
 
-    AgoData *input  = reinterpret_cast<AgoData *>(parameters[0]);
-    AgoData *output = reinterpret_cast<AgoData *>(parameters[2]);
+    vx_size temp[4] = {0};
+    uint4 input_stride, output_stride;
+    vx_size in_offset, output_offset;
+    unsigned char *input_mem = NULL;
+    unsigned char *output_mem = NULL;
+    hipStream_t hip_stream;
 
-    uint4 input_stride = make_uint4((uint)input->u.tensor.stride[0], (uint)input->u.tensor.stride[1],
-                                    (uint)input->u.tensor.stride[2], (uint)input->u.tensor.stride[3]);
+    ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_ATTRIBUTE_AMD_HIP_STREAM, &hip_stream, sizeof(hip_stream)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &input_mem, sizeof(input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_OFFSET_OPENCL, &in_offset, sizeof(in_offset)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &output_mem, sizeof(output_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_OFFSET_OPENCL, &output_offset, sizeof(output_offset)));
 
-    uint4 output_stride = make_uint4((uint)output->u.tensor.stride[0], (uint)output->u.tensor.stride[1],
-                                     (uint)output->u.tensor.stride[2], (uint)output->u.tensor.stride[3]);
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_STRIDE_OPENCL, temp, sizeof(temp)));
+    input_stride.x = temp[0];
+    input_stride.y = temp[1];
+    input_stride.z = temp[2];
+    input_stride.w = temp[3];
 
-    if (HipExec_Cast_layer(node->hip_stream0, globalThreads, dim3(1), input_type, output_type, input->hip_memory, input->u.tensor.offset, input_stride,
-            output->hip_memory, output->u.tensor.offset, output_stride)) {
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_STRIDE_OPENCL, temp, sizeof(temp)));
+    output_stride.x = temp[0];
+    output_stride.y = temp[1];
+    output_stride.z = temp[2];
+    output_stride.w = temp[3];
+
+    if (HipExec_Cast_layer(hip_stream, globalThreads, dim3(1), input_type, output_type, input_mem, in_offset, input_stride,
+            output_mem, output_offset, output_stride)) {
         return VX_FAILURE;
     }
 

--- a/amd_openvx_extensions/amd_nn/src/convolution_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/convolution_layer.cpp
@@ -415,11 +415,6 @@ static vx_status VX_CALLBACK initializeConvolutionLayer(vx_node node, const vx_r
                 return VX_FAILURE;
             }
             hipError_t errcode_ret = hipSuccess;
-            errcode_ret = hipSetDevice(hip_device);
-            if (errcode_ret != hipSuccess) {
-                return VX_FAILURE;
-            }
-
             data->workspace_size = (data->workspace_size + 3) & ~3;
             errcode_ret = hipMalloc(&data->workspace, data->workspace_size);
             if (errcode_ret != hipSuccess) {

--- a/amd_openvx_extensions/amd_nn/src/convolution_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/convolution_layer.cpp
@@ -380,16 +380,16 @@ static vx_status VX_CALLBACK initializeConvolutionLayer(vx_node node, const vx_r
             cl_context context;
             ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_OPENCL_CONTEXT, &context, sizeof(context)));
             data->workspace_size = (data->workspace_size + 3) & ~3;
-            *(cl_mem *)data->workspace = clCreateBuffer(context, CL_MEM_READ_WRITE, data->workspace_size, NULL, NULL);
+            data->workspace = clCreateBuffer(context, CL_MEM_READ_WRITE, data->workspace_size, NULL, NULL);
             if (!data->workspace) {
                 return VX_FAILURE;
             }
             cl_float pattern = 0;
             cl_int err;
             if (data->data_type == miopenFloat)
-                err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->workspace, &pattern, sizeof(cl_float), 0, data->workspace_size, 0, NULL, NULL);
+                err = clEnqueueFillBuffer(data->handle->cmdq, (cl_mem)data->workspace, &pattern, sizeof(cl_float), 0, data->workspace_size, 0, NULL, NULL);
             else
-                err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->workspace, &pattern, sizeof(cl_half), 0, data->workspace_size, 0, NULL, NULL);
+                err = clEnqueueFillBuffer(data->handle->cmdq, (cl_mem)data->workspace, &pattern, sizeof(cl_half), 0, data->workspace_size, 0, NULL, NULL);
             if(err) return VX_FAILURE;
 #elif ENABLE_HIP
             int hip_device = -1;
@@ -444,7 +444,7 @@ static vx_status VX_CALLBACK uninitializeConvolutionLayer(vx_node node, const vx
     ConvolutionLayerLocalData * data = NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
 #if ENABLE_OPENCL
-    if(data && data->workspace && clReleaseMemObject(*(cl_mem *)data->workspace) != 0) return VX_FAILURE;
+    if(data && data->workspace && clReleaseMemObject((cl_mem)data->workspace) != 0) return VX_FAILURE;
 #elif ENABLE_HIP
     if (data->workspace) {
         hipError_t errcode_ret = hipFree(data->workspace);

--- a/amd_openvx_extensions/amd_nn/src/convolution_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/convolution_layer.cpp
@@ -39,34 +39,17 @@ struct ConvolutionLayerLocalData {
     float bias_alpha, bias_beta;
     miopenDataType_t data_type;          // data_type for the kernel
     miopenTensorDescriptor_t input_desc;
-#if ENABLE_OPENCL
-    cl_mem input_mem;
-#elif ENABLE_HIP
-    vx_uint8* input_mem;
-#endif
+    void *input_mem;
     miopenTensorDescriptor_t weight_desc;
-#if ENABLE_OPENCL
-    cl_mem weight_mem;
-#elif ENABLE_HIP
-    vx_uint8* weight_mem;
-#endif
+    void *weight_mem;
     miopenConvolutionDescriptor_t conv_desc;
     miopenConvFwdAlgorithm_t algo;
     miopenTensorDescriptor_t output_desc;
-#if ENABLE_OPENCL
-    cl_mem output_mem;
-    cl_mem workspace;
-#elif ENABLE_HIP
-    vx_uint8* output_mem;
-    vx_uint8* workspace;
-#endif
+    void *output_mem;
+    void *workspace;
     size_t workspace_size;
     miopenTensorDescriptor_t bias_desc;
-#if ENABLE_OPENCL
-    cl_mem bias_mem;
-#elif ENABLE_HIP
-    vx_uint8* bias_mem;
-#endif
+    void *bias_mem;
     miopenActivationMode_t activation_mode;
     float activation_alpha;
     float activation_beta;
@@ -397,16 +380,16 @@ static vx_status VX_CALLBACK initializeConvolutionLayer(vx_node node, const vx_r
             cl_context context;
             ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_OPENCL_CONTEXT, &context, sizeof(context)));
             data->workspace_size = (data->workspace_size + 3) & ~3;
-            data->workspace = clCreateBuffer(context, CL_MEM_READ_WRITE, data->workspace_size, NULL, NULL);
+            *(cl_mem *)data->workspace = clCreateBuffer(context, CL_MEM_READ_WRITE, data->workspace_size, NULL, NULL);
             if (!data->workspace) {
                 return VX_FAILURE;
             }
             cl_float pattern = 0;
             cl_int err;
             if (data->data_type == miopenFloat)
-                err = clEnqueueFillBuffer(data->handle->cmdq, data->workspace, &pattern, sizeof(cl_float), 0, data->workspace_size, 0, NULL, NULL);
+                err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->workspace, &pattern, sizeof(cl_float), 0, data->workspace_size, 0, NULL, NULL);
             else
-                err = clEnqueueFillBuffer(data->handle->cmdq, data->workspace, &pattern, sizeof(cl_half), 0, data->workspace_size, 0, NULL, NULL);
+                err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->workspace, &pattern, sizeof(cl_half), 0, data->workspace_size, 0, NULL, NULL);
             if(err) return VX_FAILURE;
 #elif ENABLE_HIP
             int hip_device = -1;
@@ -461,10 +444,10 @@ static vx_status VX_CALLBACK uninitializeConvolutionLayer(vx_node node, const vx
     ConvolutionLayerLocalData * data = NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
 #if ENABLE_OPENCL
-    if(data->workspace && clReleaseMemObject(data->workspace) != 0) return VX_FAILURE;
+    if(data->workspace && clReleaseMemObject(*(cl_mem *)data->workspace) != 0) return VX_FAILURE;
 #elif ENABLE_HIP
     if (data->workspace) {
-        hipError_t errcode_ret = hipFree((void *)data->workspace);
+        hipError_t errcode_ret = hipFree(data->workspace);
         if (errcode_ret != hipSuccess) {
             return VX_FAILURE;
         }

--- a/amd_openvx_extensions/amd_nn/src/convolution_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/convolution_layer.cpp
@@ -444,7 +444,7 @@ static vx_status VX_CALLBACK uninitializeConvolutionLayer(vx_node node, const vx
     ConvolutionLayerLocalData * data = NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
 #if ENABLE_OPENCL
-    if(data->workspace && clReleaseMemObject(*(cl_mem *)data->workspace) != 0) return VX_FAILURE;
+    if(data && data->workspace && clReleaseMemObject(*(cl_mem *)data->workspace) != 0) return VX_FAILURE;
 #elif ENABLE_HIP
     if (data->workspace) {
         hipError_t errcode_ret = hipFree(data->workspace);

--- a/amd_openvx_extensions/amd_nn/src/convolution_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/convolution_layer.cpp
@@ -39,17 +39,34 @@ struct ConvolutionLayerLocalData {
     float bias_alpha, bias_beta;
     miopenDataType_t data_type;          // data_type for the kernel
     miopenTensorDescriptor_t input_desc;
+#if ENABLE_OPENCL
     cl_mem input_mem;
+#elif ENABLE_HIP
+    vx_uint8* input_mem;
+#endif
     miopenTensorDescriptor_t weight_desc;
+#if ENABLE_OPENCL
     cl_mem weight_mem;
+#elif ENABLE_HIP
+    vx_uint8* weight_mem;
+#endif
     miopenConvolutionDescriptor_t conv_desc;
     miopenConvFwdAlgorithm_t algo;
     miopenTensorDescriptor_t output_desc;
+#if ENABLE_OPENCL
     cl_mem output_mem;
     cl_mem workspace;
+#elif ENABLE_HIP
+    vx_uint8* output_mem;
+    vx_uint8* workspace;
+#endif
     size_t workspace_size;
     miopenTensorDescriptor_t bias_desc;
+#if ENABLE_OPENCL
     cl_mem bias_mem;
+#elif ENABLE_HIP
+    vx_uint8* bias_mem;
+#endif
     miopenActivationMode_t activation_mode;
     float activation_alpha;
     float activation_beta;
@@ -135,12 +152,22 @@ static vx_status VX_CALLBACK processConvolutionLayer(vx_node node, const vx_refe
 PROFILER_START(VX_NN, Convolution_Layer)
     ConvolutionLayerLocalData * data= NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[4], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->weight_mem, sizeof(data->weight_mem)));
     if(parameters[2]) {
         ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_OPENCL, &data->bias_mem, sizeof(data->bias_mem)));
     }
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[4], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->weight_mem, sizeof(data->weight_mem)));
+    if(parameters[2]) {
+        ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &data->bias_mem, sizeof(data->bias_mem)));
+    }
+#endif
+
     if (data->fusion_possible == true)
     {
         // Set the Args
@@ -294,6 +321,7 @@ static vx_status VX_CALLBACK initializeConvolutionLayer(vx_node node, const vx_r
     //Grouped Convolution
     ERROR_CHECK_MIOPEN_STATUS(miopenSetConvolutionGroupCount(data->conv_desc, data->groupCount));
 
+#if ENABLE_OPENCL
     //Memory Declaration.
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[4], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
@@ -301,6 +329,15 @@ static vx_status VX_CALLBACK initializeConvolutionLayer(vx_node node, const vx_r
     if(parameters[2]) {
         ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_OPENCL, &data->bias_mem, sizeof(data->bias_mem)));
     }
+#elif ENABLE_HIP
+    //Memory Declaration.
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[4], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->weight_mem, sizeof(data->weight_mem)));
+    if(parameters[2]) {
+        ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &data->bias_mem, sizeof(data->bias_mem)));
+    }
+#endif
 
     if (/*(data->bias_activ_mode == BIAS_ONLY_FUSED) || (data->bias_activ_mode == ACTIVATION_ONLY_FUSED) ||*/ (data->bias_activ_mode == BIAS_ACTIVATION_FUSED)) {
         ERROR_CHECK_MIOPEN_STATUS(miopenCreateFusionPlan(&data->fusePlanDesc, miopenVerticalFusion, data->input_desc));
@@ -356,6 +393,7 @@ static vx_status VX_CALLBACK initializeConvolutionLayer(vx_node node, const vx_r
         ERROR_CHECK_MIOPEN_STATUS(miopenConvolutionForwardGetWorkSpaceSize(data->handle->miopen_handle, data->weight_desc, data->input_desc, data->conv_desc, data->output_desc, &data->workspace_size ));
         if (data->workspace_size > 0) {
             vx_context   vxContext = vxGetContext((vx_reference)node);
+#if ENABLE_OPENCL
             cl_context context;
             ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_OPENCL_CONTEXT, &context, sizeof(context)));
             data->workspace_size = (data->workspace_size + 3) & ~3;
@@ -370,6 +408,29 @@ static vx_status VX_CALLBACK initializeConvolutionLayer(vx_node node, const vx_r
             else
                 err = clEnqueueFillBuffer(data->handle->cmdq, data->workspace, &pattern, sizeof(cl_half), 0, data->workspace_size, 0, NULL, NULL);
             if(err) return VX_FAILURE;
+#elif ENABLE_HIP
+            int hip_device = -1;
+            ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_HIP_DEVICE, &hip_device, sizeof(hip_device)));
+            if (hip_device < 0) {
+                return VX_FAILURE;
+            }
+            hipError_t errcode_ret = hipSuccess;
+            errcode_ret = hipSetDevice(hip_device);
+            if (errcode_ret != hipSuccess) {
+                return VX_FAILURE;
+            }
+
+            data->workspace_size = (data->workspace_size + 3) & ~3;
+            errcode_ret = hipMalloc(&data->workspace, data->workspace_size);
+            if (errcode_ret != hipSuccess) {
+                return VX_FAILURE;
+            }
+
+            errcode_ret = hipMemset(data->workspace, 0, data->workspace_size);
+            if (errcode_ret != hipSuccess) {
+                return VX_FAILURE;
+            }
+#endif
         }
         //Finding best Convolution Algorithm.
         miopenConvAlgoPerf_t perf;
@@ -404,7 +465,16 @@ static vx_status VX_CALLBACK uninitializeConvolutionLayer(vx_node node, const vx
 {
     ConvolutionLayerLocalData * data = NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
+#if ENABLE_OPENCL
     if(data->workspace && clReleaseMemObject(data->workspace) != 0) return VX_FAILURE;
+#elif ENABLE_HIP
+    if (data->workspace) {
+        hipError_t errcode_ret = hipFree((void *)data->workspace);
+        if (errcode_ret != hipSuccess) {
+            return VX_FAILURE;
+        }
+    }
+#endif
     if (data->fusePlanDesc) miopenDestroyFusionPlan(data->fusePlanDesc);
     if (data->fusionArgs) miopenDestroyOperatorArgs(data->fusionArgs);
     ERROR_CHECK_MIOPEN_STATUS(miopenDestroyConvolutionDescriptor(data->conv_desc));

--- a/amd_openvx_extensions/amd_nn/src/deconvolution_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/deconvolution_layer.cpp
@@ -35,17 +35,34 @@ struct DeconvolutionLayerLocalData {
     float beta;
     miopenDataType_t data_type;          // data_type for the kernel
     miopenTensorDescriptor_t input_desc;
+#if ENABLE_OPENCL
     cl_mem input_mem;
+#elif ENABLE_HIP
+    vx_uint8* input_mem;
+#endif
     miopenTensorDescriptor_t weight_desc;
+#if ENABLE_OPENCL
     cl_mem weight_mem;
+#elif ENABLE_HIP
+    vx_uint8* weight_mem;
+#endif
     miopenConvolutionDescriptor_t deconv_desc;
     miopenConvFwdAlgorithm_t algo;
     miopenTensorDescriptor_t output_desc;
+#if ENABLE_OPENCL
     cl_mem output_mem;
     cl_mem workspace;
+#elif ENABLE_HIP
+    vx_uint8* output_mem;
+    vx_uint8* workspace;
+#endif
     size_t workspace_size;
     miopenTensorDescriptor_t bias_desc;
+#if ENABLE_OPENCL
     cl_mem bias_mem;
+#elif ENABLE_HIP
+    vx_uint8* bias_mem;
+#endif
 };
 
 static vx_status VX_CALLBACK validateDeconvolutionLayer(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])
@@ -103,8 +120,14 @@ PROFILER_START(VX_NN, Deconvolution_Layer)
     DeconvolutionLayerLocalData * data= NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
 
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[4], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[4], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
+
 
     ERROR_CHECK_MIOPEN_STATUS(miopenConvolutionForward(data->handle->miopen_handle, &data->alpha, data->input_desc, data->input_mem,
                                                        data->weight_desc,data->weight_mem,data->deconv_desc,data->algo,&data->beta, data->output_desc, data->output_mem, data->workspace, data->workspace_size));
@@ -181,6 +204,7 @@ static vx_status VX_CALLBACK initializeDeconvolutionLayer(vx_node node, const vx
     ERROR_CHECK_MIOPEN_STATUS(miopenCreateConvolutionDescriptor(&data->deconv_desc));
     ERROR_CHECK_MIOPEN_STATUS(miopenInitConvolutionDescriptor(data->deconv_desc, mode, pad_h, pad_w, stride_h, stride_w, dilation_h, dilation_w));
 
+#if ENABLE_OPENCL
     //Memory Declaration.
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[4], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
@@ -188,11 +212,21 @@ static vx_status VX_CALLBACK initializeDeconvolutionLayer(vx_node node, const vx
     if(parameters[2]) {
         ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_OPENCL, &data->bias_mem, sizeof(data->bias_mem)));
     }
+#elif ENABLE_HIP
+    //Memory Declaration.
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[4], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->weight_mem, sizeof(data->weight_mem)));
+    if(parameters[2]) {
+        ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &data->bias_mem, sizeof(data->bias_mem)));
+    }
+#endif
 
     //Workspace Size.
     ERROR_CHECK_MIOPEN_STATUS(miopenConvolutionForwardGetWorkSpaceSize(data->handle->miopen_handle, data->weight_desc, data->input_desc, data->deconv_desc, data->output_desc, &data->workspace_size ));
     if (data->workspace_size > 0) {
         vx_context   vxContext = vxGetContext((vx_reference)node);
+#if ENABLE_OPENCL
         cl_context context;
         ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_OPENCL_CONTEXT, &context, sizeof(context)));
         cl_int err;
@@ -207,6 +241,29 @@ static vx_status VX_CALLBACK initializeDeconvolutionLayer(vx_node node, const vx
         else
             err = clEnqueueFillBuffer(data->handle->cmdq, data->workspace, &pattern, sizeof(cl_half), 0, data->workspace_size, 0, NULL, NULL);
         if(err!=0) return VX_FAILURE;
+#elif ENABLE_HIP
+            int hip_device = -1;
+            ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_HIP_DEVICE, &hip_device, sizeof(hip_device)));
+            if (hip_device < 0) {
+                return VX_FAILURE;
+            }
+            hipError_t errcode_ret = hipSuccess;
+            errcode_ret = hipSetDevice(hip_device);
+            if (errcode_ret != hipSuccess) {
+                return VX_FAILURE;
+            }
+
+            data->workspace_size = (data->workspace_size + 3) & ~3;
+            errcode_ret = hipMalloc(&data->workspace, data->workspace_size);
+            if (errcode_ret != hipSuccess) {
+                return VX_FAILURE;
+            }
+
+            errcode_ret = hipMemset(data->workspace, 0, data->workspace_size);
+            if (errcode_ret != hipSuccess) {
+                return VX_FAILURE;
+            }
+#endif
     }
 
     data->alpha = 1;
@@ -239,7 +296,16 @@ static vx_status VX_CALLBACK uninitializeDeconvolutionLayer(vx_node node, const 
 {
     DeconvolutionLayerLocalData * data = NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
+#if ENABLE_OPENCL
     if(data->workspace && clReleaseMemObject(data->workspace) != 0) return VX_FAILURE;
+#elif ENABLE_HIP
+    if (data->workspace) {
+        hipError_t errcode_ret = hipFree((void *)data->workspace);
+        if (errcode_ret != hipSuccess) {
+            return VX_FAILURE;
+        }
+    }
+#endif
     ERROR_CHECK_MIOPEN_STATUS(miopenDestroyConvolutionDescriptor(data->deconv_desc));
     ERROR_CHECK_MIOPEN_STATUS(miopenDestroyTensorDescriptor(data->input_desc));
     ERROR_CHECK_MIOPEN_STATUS(miopenDestroyTensorDescriptor(data->output_desc));

--- a/amd_openvx_extensions/amd_nn/src/deconvolution_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/deconvolution_layer.cpp
@@ -35,34 +35,17 @@ struct DeconvolutionLayerLocalData {
     float beta;
     miopenDataType_t data_type;          // data_type for the kernel
     miopenTensorDescriptor_t input_desc;
-#if ENABLE_OPENCL
-    cl_mem input_mem;
-#elif ENABLE_HIP
-    vx_uint8* input_mem;
-#endif
+    void *input_mem;
     miopenTensorDescriptor_t weight_desc;
-#if ENABLE_OPENCL
-    cl_mem weight_mem;
-#elif ENABLE_HIP
-    vx_uint8* weight_mem;
-#endif
+    void *weight_mem;
     miopenConvolutionDescriptor_t deconv_desc;
     miopenConvFwdAlgorithm_t algo;
     miopenTensorDescriptor_t output_desc;
-#if ENABLE_OPENCL
-    cl_mem output_mem;
-    cl_mem workspace;
-#elif ENABLE_HIP
-    vx_uint8* output_mem;
-    vx_uint8* workspace;
-#endif
+    void *output_mem;
+    void *workspace;
     size_t workspace_size;
     miopenTensorDescriptor_t bias_desc;
-#if ENABLE_OPENCL
-    cl_mem bias_mem;
-#elif ENABLE_HIP
-    vx_uint8* bias_mem;
-#endif
+    void *bias_mem;
 };
 
 static vx_status VX_CALLBACK validateDeconvolutionLayer(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])
@@ -231,15 +214,15 @@ static vx_status VX_CALLBACK initializeDeconvolutionLayer(vx_node node, const vx
         ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_OPENCL_CONTEXT, &context, sizeof(context)));
         cl_int err;
         data->workspace_size = (data->workspace_size + 3) & ~3;
-        data->workspace = clCreateBuffer(context, CL_MEM_READ_WRITE, data->workspace_size, NULL, &err);
+        *(cl_mem *)data->workspace = clCreateBuffer(context, CL_MEM_READ_WRITE, data->workspace_size, NULL, &err);
         if(err!=0) return VX_FAILURE;
         if (!data->workspace) return VX_FAILURE;
 
         cl_float pattern = 0;
         if (data->data_type == miopenFloat)
-            err = clEnqueueFillBuffer(data->handle->cmdq, data->workspace, &pattern, sizeof(cl_float), 0, data->workspace_size, 0, NULL, NULL);
+            err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->workspace, &pattern, sizeof(cl_float), 0, data->workspace_size, 0, NULL, NULL);
         else
-            err = clEnqueueFillBuffer(data->handle->cmdq, data->workspace, &pattern, sizeof(cl_half), 0, data->workspace_size, 0, NULL, NULL);
+            err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->workspace, &pattern, sizeof(cl_half), 0, data->workspace_size, 0, NULL, NULL);
         if(err!=0) return VX_FAILURE;
 #elif ENABLE_HIP
             int hip_device = -1;
@@ -292,10 +275,10 @@ static vx_status VX_CALLBACK uninitializeDeconvolutionLayer(vx_node node, const 
     DeconvolutionLayerLocalData * data = NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
 #if ENABLE_OPENCL
-    if(data->workspace && clReleaseMemObject(data->workspace) != 0) return VX_FAILURE;
+    if(data->workspace && clReleaseMemObject(*(cl_mem *)data->workspace) != 0) return VX_FAILURE;
 #elif ENABLE_HIP
     if (data->workspace) {
-        hipError_t errcode_ret = hipFree((void *)data->workspace);
+        hipError_t errcode_ret = hipFree(data->workspace);
         if (errcode_ret != hipSuccess) {
             return VX_FAILURE;
         }

--- a/amd_openvx_extensions/amd_nn/src/deconvolution_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/deconvolution_layer.cpp
@@ -214,15 +214,15 @@ static vx_status VX_CALLBACK initializeDeconvolutionLayer(vx_node node, const vx
         ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_OPENCL_CONTEXT, &context, sizeof(context)));
         cl_int err;
         data->workspace_size = (data->workspace_size + 3) & ~3;
-        *(cl_mem *)data->workspace = clCreateBuffer(context, CL_MEM_READ_WRITE, data->workspace_size, NULL, &err);
+        data->workspace = clCreateBuffer(context, CL_MEM_READ_WRITE, data->workspace_size, NULL, &err);
         if(err!=0) return VX_FAILURE;
         if (!data->workspace) return VX_FAILURE;
 
         cl_float pattern = 0;
         if (data->data_type == miopenFloat)
-            err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->workspace, &pattern, sizeof(cl_float), 0, data->workspace_size, 0, NULL, NULL);
+            err = clEnqueueFillBuffer(data->handle->cmdq, (cl_mem)data->workspace, &pattern, sizeof(cl_float), 0, data->workspace_size, 0, NULL, NULL);
         else
-            err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->workspace, &pattern, sizeof(cl_half), 0, data->workspace_size, 0, NULL, NULL);
+            err = clEnqueueFillBuffer(data->handle->cmdq, (cl_mem)data->workspace, &pattern, sizeof(cl_half), 0, data->workspace_size, 0, NULL, NULL);
         if(err!=0) return VX_FAILURE;
 #elif ENABLE_HIP
             int hip_device = -1;
@@ -275,7 +275,7 @@ static vx_status VX_CALLBACK uninitializeDeconvolutionLayer(vx_node node, const 
     DeconvolutionLayerLocalData * data = NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
 #if ENABLE_OPENCL
-    if(data && data->workspace && clReleaseMemObject(*(cl_mem *)data->workspace) != 0) return VX_FAILURE;
+    if(data && data->workspace && clReleaseMemObject((cl_mem)data->workspace) != 0) return VX_FAILURE;
 #elif ENABLE_HIP
     if (data->workspace) {
         hipError_t errcode_ret = hipFree(data->workspace);

--- a/amd_openvx_extensions/amd_nn/src/deconvolution_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/deconvolution_layer.cpp
@@ -275,7 +275,7 @@ static vx_status VX_CALLBACK uninitializeDeconvolutionLayer(vx_node node, const 
     DeconvolutionLayerLocalData * data = NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
 #if ENABLE_OPENCL
-    if(data->workspace && clReleaseMemObject(*(cl_mem *)data->workspace) != 0) return VX_FAILURE;
+    if(data && data->workspace && clReleaseMemObject(*(cl_mem *)data->workspace) != 0) return VX_FAILURE;
 #elif ENABLE_HIP
     if (data->workspace) {
         hipError_t errcode_ret = hipFree(data->workspace);

--- a/amd_openvx_extensions/amd_nn/src/deconvolution_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/deconvolution_layer.cpp
@@ -248,11 +248,6 @@ static vx_status VX_CALLBACK initializeDeconvolutionLayer(vx_node node, const vx
                 return VX_FAILURE;
             }
             hipError_t errcode_ret = hipSuccess;
-            errcode_ret = hipSetDevice(hip_device);
-            if (errcode_ret != hipSuccess) {
-                return VX_FAILURE;
-            }
-
             data->workspace_size = (data->workspace_size + 3) & ~3;
             errcode_ret = hipMalloc(&data->workspace, data->workspace_size);
             if (errcode_ret != hipSuccess) {

--- a/amd_openvx_extensions/amd_nn/src/fully_connected_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/fully_connected_layer.cpp
@@ -248,7 +248,7 @@ static vx_status VX_CALLBACK uninitializeFullyConnectedLayer(vx_node node, const
     FullyConnectedLayerLocalData * data = NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
 #if ENABLE_OPENCL
-    if(data->workspace && clReleaseMemObject(*(cl_mem *)data->workspace) != 0 ) return VX_FAILURE;
+    if(data && data->workspace && clReleaseMemObject(*(cl_mem *)data->workspace) != 0 ) return VX_FAILURE;
 #elif ENABLE_HIP
     if (data->workspace) {
         hipError_t errcode_ret = hipFree(data->workspace);

--- a/amd_openvx_extensions/amd_nn/src/fully_connected_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/fully_connected_layer.cpp
@@ -198,13 +198,13 @@ static vx_status VX_CALLBACK initializeFullyConnectedLayer(vx_node node, const v
         cl_context context;
         ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_OPENCL_CONTEXT, &context, sizeof(context)));
         data->workspace_size = (data->workspace_size + 3) & ~3;
-        *(cl_mem *)data->workspace = clCreateBuffer(context, CL_MEM_READ_WRITE, data->workspace_size, NULL, NULL);
+        data->workspace = clCreateBuffer(context, CL_MEM_READ_WRITE, data->workspace_size, NULL, NULL);
         if (!data->workspace) {
             return VX_FAILURE;
         }
         cl_float pattern = 0;
         cl_int err = 0;
-        err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->workspace, &pattern, sizeof(cl_float), 0, data->workspace_size, 0, NULL, NULL);
+        err = clEnqueueFillBuffer(data->handle->cmdq, (cl_mem)data->workspace, &pattern, sizeof(cl_float), 0, data->workspace_size, 0, NULL, NULL);
         if(err) return VX_FAILURE;
 #elif ENABLE_HIP
         int hip_device = -1;
@@ -248,7 +248,7 @@ static vx_status VX_CALLBACK uninitializeFullyConnectedLayer(vx_node node, const
     FullyConnectedLayerLocalData * data = NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
 #if ENABLE_OPENCL
-    if(data && data->workspace && clReleaseMemObject(*(cl_mem *)data->workspace) != 0 ) return VX_FAILURE;
+    if(data && data->workspace && clReleaseMemObject((cl_mem)data->workspace) != 0 ) return VX_FAILURE;
 #elif ENABLE_HIP
     if (data->workspace) {
         hipError_t errcode_ret = hipFree(data->workspace);

--- a/amd_openvx_extensions/amd_nn/src/fully_connected_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/fully_connected_layer.cpp
@@ -224,11 +224,6 @@ static vx_status VX_CALLBACK initializeFullyConnectedLayer(vx_node node, const v
             return VX_FAILURE;
         }
         hipError_t errcode_ret = hipSuccess;
-        errcode_ret = hipSetDevice(hip_device);
-        if (errcode_ret != hipSuccess) {
-            return VX_FAILURE;
-        }
-
         data->workspace_size = (data->workspace_size + 3) & ~3;
         errcode_ret = hipMalloc(&data->workspace, data->workspace_size);
         if (errcode_ret != hipSuccess) {

--- a/amd_openvx_extensions/amd_nn/src/fully_connected_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/fully_connected_layer.cpp
@@ -30,15 +30,27 @@ struct FullyConnectedLayerLocalData {
     miopenTensorDescriptor_t weight_desc;
     miopenTensorDescriptor_t bias_desc;
     miopenDataType_t data_type;          // data_type for the kernel
+#if ENABLE_OPENCL
     cl_mem input_mem;
     cl_mem output_mem;
     cl_mem weight_mem;
     cl_mem bias_mem;
+#elif ENABLE_HIP
+    vx_uint8* input_mem;
+    vx_uint8* output_mem;
+    vx_uint8* weight_mem;
+    vx_uint8* bias_mem;
+#endif
     miopenConvFwdAlgorithm_t algo;
     size_t workspace_size;
     float alpha;
     float beta;
+#if ENABLE_OPENCL
     cl_mem workspace;
+#elif ENABLE_HIP
+    vx_uint8* workspace;
+#endif
+
 };
 
 static vx_status VX_CALLBACK validateFullyConnectedLayer(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])
@@ -98,8 +110,13 @@ PROFILER_START(VX_NN, Fully_Connected_Layer)
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     miopenHandle_t miopen_handle = data->handle->miopen_handle;
 
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
     //ConvolutionForward.
     ERROR_CHECK_MIOPEN_STATUS(miopenConvolutionForward(data->handle->miopen_handle, &data->alpha, data->input_desc, data->input_mem,
@@ -164,6 +181,7 @@ static vx_status VX_CALLBACK initializeFullyConnectedLayer(vx_node node, const v
     ERROR_CHECK_MIOPEN_STATUS(miopenCreateConvolutionDescriptor(&data->convdesc));
     ERROR_CHECK_MIOPEN_STATUS(miopenInitConvolutionDescriptor(data->convdesc, mode, 0, 0, 1, 1, 1, 1));
 
+#if ENABLE_OPENCL
     //Memory Declaration.
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
@@ -171,6 +189,15 @@ static vx_status VX_CALLBACK initializeFullyConnectedLayer(vx_node node, const v
     if(parameters[2]) {
         ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_OPENCL, &data->bias_mem, sizeof(data->bias_mem)));
     }
+#elif ENABLE_HIP
+    //Memory Declaration.
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->weight_mem, sizeof(data->weight_mem)));
+    if(parameters[2]) {
+        ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &data->bias_mem, sizeof(data->bias_mem)));
+    }
+#endif
     data->alpha = 1;
     data->beta = 0;
 
@@ -178,6 +205,7 @@ static vx_status VX_CALLBACK initializeFullyConnectedLayer(vx_node node, const v
     ERROR_CHECK_MIOPEN_STATUS(miopenConvolutionForwardGetWorkSpaceSize(data->handle->miopen_handle, data->weight_desc, data->input_desc, data->convdesc, data->output_desc, &data->workspace_size ));
     if (data->workspace_size > 0) {
         vx_context   vxContext = vxGetContext((vx_reference)node);
+#if ENABLE_OPENCL
         cl_context context;
         ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_OPENCL_CONTEXT, &context, sizeof(context)));
         data->workspace_size = (data->workspace_size + 3) & ~3;
@@ -189,6 +217,29 @@ static vx_status VX_CALLBACK initializeFullyConnectedLayer(vx_node node, const v
         cl_int err = 0;
         err = clEnqueueFillBuffer(data->handle->cmdq, data->workspace, &pattern, sizeof(cl_float), 0, data->workspace_size, 0, NULL, NULL);
         if(err) return VX_FAILURE;
+#elif ENABLE_HIP
+        int hip_device = -1;
+        ERROR_CHECK_STATUS(vxQueryContext(vxContext, VX_CONTEXT_ATTRIBUTE_AMD_HIP_DEVICE, &hip_device, sizeof(hip_device)));
+        if (hip_device < 0) {
+            return VX_FAILURE;
+        }
+        hipError_t errcode_ret = hipSuccess;
+        errcode_ret = hipSetDevice(hip_device);
+        if (errcode_ret != hipSuccess) {
+            return VX_FAILURE;
+        }
+
+        data->workspace_size = (data->workspace_size + 3) & ~3;
+        errcode_ret = hipMalloc(&data->workspace, data->workspace_size);
+        if (errcode_ret != hipSuccess) {
+            return VX_FAILURE;
+        }
+
+        errcode_ret = hipMemset(data->workspace, 0, data->workspace_size);
+        if (errcode_ret != hipSuccess) {
+            return VX_FAILURE;
+        }
+#endif
     }
     //Finding best Convolution Algorithm.
     miopenConvAlgoPerf_t perf;
@@ -212,7 +263,16 @@ static vx_status VX_CALLBACK uninitializeFullyConnectedLayer(vx_node node, const
 {
     FullyConnectedLayerLocalData * data = NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
+#if ENABLE_OPENCL
     if(data->workspace && clReleaseMemObject(data->workspace) != 0 ) return VX_FAILURE;
+#elif ENABLE_HIP
+    if (data->workspace) {
+        hipError_t errcode_ret = hipFree((void *)data->workspace);
+        if (errcode_ret != hipSuccess) {
+            return VX_FAILURE;
+        }
+    }
+#endif
     ERROR_CHECK_MIOPEN_STATUS(miopenDestroyConvolutionDescriptor(data->convdesc));
     ERROR_CHECK_MIOPEN_STATUS(miopenDestroyTensorDescriptor(data->input_desc));
     ERROR_CHECK_MIOPEN_STATUS(miopenDestroyTensorDescriptor(data->output_desc));

--- a/amd_openvx_extensions/amd_nn/src/gather_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/gather_layer.cpp
@@ -215,21 +215,42 @@ static vx_status VX_CALLBACK host_kernel(vx_node node, const vx_reference * para
         globalThreads.y *= input_dims2[i];
     }
 
-    AgoData *input  = reinterpret_cast<AgoData *>(parameters[0]);
-    AgoData *ind    = reinterpret_cast<AgoData *>(parameters[1]);
-    AgoData *output = reinterpret_cast<AgoData *>(parameters[2]);
+    vx_size temp[4] = {0};
+    uint4 input_stride, ind_stride, output_stride;
+    vx_size in_offset, ind_offset, output_offset;
+    unsigned char *input_mem = NULL;
+    unsigned char *ind_mem = NULL;
+    unsigned char *output_mem = NULL;
+    hipStream_t hip_stream;
 
-    uint4 input_stride = make_uint4((uint)input->u.tensor.stride[0], (uint)input->u.tensor.stride[1],
-                                    (uint)input->u.tensor.stride[2], (uint)input->u.tensor.stride[3]);
+    ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_ATTRIBUTE_AMD_HIP_STREAM, &hip_stream, sizeof(hip_stream)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &input_mem, sizeof(input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_OFFSET_OPENCL, &in_offset, sizeof(in_offset)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &ind_mem, sizeof(ind_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_OFFSET_OPENCL, &ind_offset, sizeof(ind_offset)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &output_mem, sizeof(output_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_OFFSET_OPENCL, &output_offset, sizeof(output_offset)));
 
-    uint4 ind_stride = make_uint4((uint)ind->u.tensor.stride[0], (uint)ind->u.tensor.stride[1],
-                                  (uint)ind->u.tensor.stride[2], (uint)ind->u.tensor.stride[3]);
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_STRIDE_OPENCL, temp, sizeof(temp)));
+    input_stride.x = temp[0];
+    input_stride.y = temp[1];
+    input_stride.z = temp[2];
+    input_stride.w = temp[3];
 
-    uint4 output_stride = make_uint4((uint)output->u.tensor.stride[0], (uint)output->u.tensor.stride[1],
-                                     (uint)output->u.tensor.stride[2], (uint)output->u.tensor.stride[3]);
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_STRIDE_OPENCL, temp, sizeof(temp)));
+    ind_stride.x = temp[0];
+    ind_stride.y = temp[1];
+    ind_stride.z = temp[2];
+    ind_stride.w = temp[3];
 
-    if (HipExec_Gather_layer(node->hip_stream0, globalThreads, dim3(1), type, input->hip_memory, input->u.tensor.offset, input_stride,
-        ind->hip_memory, ind->u.tensor.offset, ind_stride, output->hip_memory, output->u.tensor.offset, output_stride, axis)) {
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_STRIDE_OPENCL, temp, sizeof(temp)));
+    output_stride.x = temp[0];
+    output_stride.y = temp[1];
+    output_stride.z = temp[2];
+    output_stride.w = temp[3];
+
+    if (HipExec_Gather_layer(hip_stream, globalThreads, dim3(1), type, input_mem, in_offset, input_stride,
+        ind_mem, ind_offset, ind_stride, output_mem, output_offset, output_stride, axis)) {
         return VX_FAILURE;
     }
 

--- a/amd_openvx_extensions/amd_nn/src/image_tensor_converter.cpp
+++ b/amd_openvx_extensions/amd_nn/src/image_tensor_converter.cpp
@@ -243,18 +243,34 @@ static vx_status VX_CALLBACK host_kernel(vx_node node, const vx_reference * para
     height = (vx_uint32)output_dims[1];
     N = (vx_uint32)output_dims[3];
 
-    AgoData *input  = reinterpret_cast<AgoData *>(parameters[0]);
-    AgoData *output = reinterpret_cast<AgoData *>(parameters[1]);
-    AgoData *sc1 = reinterpret_cast<AgoData *>(parameters[2]);
-    AgoData *sc2 = reinterpret_cast<AgoData *>(parameters[3]);
-    AgoData *reverse_channel_order = reinterpret_cast<AgoData *>(parameters[4]);
+    vx_size temp[4] = {0};
+    uint4 output_stride;
+    vx_size output_offset;
+    vx_uint32 input_offset, input_stride;
+    unsigned char *input_mem = NULL;
+    unsigned char *output_mem = NULL;
+    float sc1, sc2;
+    uint reverse_channel_order;
+    hipStream_t hip_stream;
 
-    uint4 output_stride = make_uint4((uint)output->u.tensor.stride[0], (uint)output->u.tensor.stride[1],
-                                     (uint)output->u.tensor.stride[2], (uint)output->u.tensor.stride[3]);
+    ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_ATTRIBUTE_AMD_HIP_STREAM, &hip_stream, sizeof(hip_stream)));
+    ERROR_CHECK_STATUS(vxQueryImage((vx_image)parameters[0], VX_IMAGE_ATTRIBUTE_AMD_HIP_BUFFER, &input_mem, sizeof(input_mem)));
+    ERROR_CHECK_STATUS(vxQueryImage((vx_image)parameters[0], VX_IMAGE_ATTRIBUTE_AMD_GPU_BUFFER_OFFSET, &input_offset, sizeof(input_offset)));
+    ERROR_CHECK_STATUS(vxQueryImage((vx_image)parameters[0], VX_IMAGE_ATTRIBUTE_AMD_GPU_BUFFER_STRIDE, &input_stride, sizeof(input_stride)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &output_mem, sizeof(output_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_OFFSET_OPENCL, &output_offset, sizeof(output_offset)));
+    ERROR_CHECK_STATUS(vxReadScalarValue((vx_scalar)parameters[2], &sc1));
+    ERROR_CHECK_STATUS(vxReadScalarValue((vx_scalar)parameters[3], &sc2));
+    ERROR_CHECK_STATUS(vxReadScalarValue((vx_scalar)parameters[4], &reverse_channel_order));
 
-    if (HipExec_image_to_tensor_layer(node->hip_stream0, format, type, width, height, N, input->hip_memory, input->gpu_buffer_offset,
-        input->u.img.stride_in_bytes, output->hip_memory, output->u.tensor.offset, output_stride, sc1->u.scalar.u.f, sc2->u.scalar.u.f,
-        reverse_channel_order->u.scalar.u.u)) {
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_STRIDE_OPENCL, temp, sizeof(temp)));
+    output_stride.x = temp[0];
+    output_stride.y = temp[1];
+    output_stride.z = temp[2];
+    output_stride.w = temp[3];
+
+    if (HipExec_image_to_tensor_layer(hip_stream, format, type, width, height, N, input_mem, input_offset,
+        input_stride, output_mem, output_offset, output_stride, sc1, sc2, reverse_channel_order)) {
         return VX_FAILURE;
     }
 

--- a/amd_openvx_extensions/amd_nn/src/kernels.cpp
+++ b/amd_openvx_extensions/amd_nn/src/kernels.cpp
@@ -116,10 +116,16 @@ vx_status createGraphHandle(vx_node node, NeuralNetworkCommonHandle ** pHandle)
             handle->exhaustiveSearch = true;
 
         handle->count = 1;
+
+#if ENABLE_OPENCL
         ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_ATTRIBUTE_AMD_OPENCL_COMMAND_QUEUE, &handle->cmdq, sizeof(handle->cmdq)));
-        
+#elif ENABLE_HIP
+        ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_ATTRIBUTE_AMD_HIP_STREAM, &handle->cmdq, sizeof(handle->cmdq)));
+#endif
+
         //create miopen_handle from cmdq
         ERROR_CHECK_MIOPEN_STATUS(miopenCreateWithStream(&handle->miopen_handle, handle->cmdq));
+
         ERROR_CHECK_STATUS(vxSetModuleHandle(node, OPENVX_KHR_NN, handle));
     }
     *pHandle = handle;

--- a/amd_openvx_extensions/amd_nn/src/kernels.h
+++ b/amd_openvx_extensions/amd_nn/src/kernels.h
@@ -48,7 +48,12 @@ THE SOFTWARE.
 #if __APPLE__
 #include <opencl.h>
 #else
+#if ENABLE_OPENCL
 #include <CL/cl.h>
+#elif ENABLE_HIP
+#include  "../../../amd_openvx/openvx/ago/ago_internal.h"
+#include "../nn_hip/nn_hip_host_decls.h"
+#endif
 #endif
 #if _WIN32
 #include <windows.h>
@@ -56,11 +61,6 @@ THE SOFTWARE.
 #include <sys/stat.h>
 #include <stdlib.h>
 #include <ctype.h>
-#endif
-
-#if ENABLE_HIP
-#include  "../../../amd_openvx/openvx/ago/ago_internal.h"
-#include "../nn_hip/nn_hip_host_decls.h"
 #endif
 
 // Visual Profiler (enabled by setting PROFILER_MODE=1 in profiler.h)
@@ -129,7 +129,11 @@ enum user_kernel_e
 struct NeuralNetworkCommonHandle {
     int count;
     miopenHandle_t  miopen_handle;
+#if ENABLE_OPENCL
     cl_command_queue cmdq;
+#elif ENABLE_HIP
+    hipStream_t cmdq;
+#endif
     bool exhaustiveSearch;
 };
 

--- a/amd_openvx_extensions/amd_nn/src/kernels.h
+++ b/amd_openvx_extensions/amd_nn/src/kernels.h
@@ -51,7 +51,6 @@ THE SOFTWARE.
 #if ENABLE_OPENCL
 #include <CL/cl.h>
 #elif ENABLE_HIP
-#include  "../../../amd_openvx/openvx/ago/ago_internal.h"
 #include "../nn_hip/nn_hip_host_decls.h"
 #endif
 #endif

--- a/amd_openvx_extensions/amd_nn/src/local_response_normalization_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/local_response_normalization_layer.cpp
@@ -31,19 +31,10 @@ struct LocalResponseNormalizationLayerLocalData {
     double normBeta;
     double normBias;
     miopenTensorDescriptor_t input_desc;
-#if ENABLE_OPENCL
-    cl_mem input_mem;
-#elif ENABLE_HIP
-    vx_uint8* input_mem;
-#endif
+    void *input_mem;
     miopenTensorDescriptor_t output_desc;
-#if ENABLE_OPENCL
-    cl_mem output_mem;
-    cl_mem workspace;
-#elif ENABLE_HIP
-    vx_uint8* output_mem;
-    vx_uint8* workspace;
-#endif
+    void *output_mem;
+    void *workspace;
     size_t workspace_size;
 };
 

--- a/amd_openvx_extensions/amd_nn/src/local_response_normalization_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/local_response_normalization_layer.cpp
@@ -31,10 +31,19 @@ struct LocalResponseNormalizationLayerLocalData {
     double normBeta;
     double normBias;
     miopenTensorDescriptor_t input_desc;
+#if ENABLE_OPENCL
     cl_mem input_mem;
+#elif ENABLE_HIP
+    vx_uint8* input_mem;
+#endif
     miopenTensorDescriptor_t output_desc;
+#if ENABLE_OPENCL
     cl_mem output_mem;
     cl_mem workspace;
+#elif ENABLE_HIP
+    vx_uint8* output_mem;
+    vx_uint8* workspace;
+#endif
     size_t workspace_size;
 };
 
@@ -89,8 +98,13 @@ PROFILER_START(VX_NN, Local_Response_Normalization_Layer)
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     miopenHandle_t miopenHandle = data->handle->miopen_handle;
 
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
     float alpha = 1.0f, beta = 0.0f;
     //Apply Local Response Normalization forward.
@@ -150,9 +164,15 @@ static vx_status VX_CALLBACK initializeLocalResponseNormalizationLayer(vx_node n
     ERROR_CHECK_MIOPEN_STATUS(miopenCreateLRNDescriptor(&data->lrnDesc));
     ERROR_CHECK_MIOPEN_STATUS(miopenSetLRNDescriptor(data->lrnDesc, data->mode, data->normN, data->normAlpha, data->normBeta, data->normBias));
 
+#if ENABLE_OPENCL
     //Input and output memory.
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    //Input and output memory.
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
 #if ENABLE_DEBUG_PRINT_DIMS
     std::cout << "lrn input " << input_dims[3] << " " << input_dims[2] << " " << input_dims[1] << " " << input_dims[0] << " ";

--- a/amd_openvx_extensions/amd_nn/src/normalization_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/normalization_layer.cpp
@@ -31,19 +31,10 @@ struct NormalizationLayerLocalData {
     double normBeta;
     double normBias;
     miopenTensorDescriptor_t input_desc;
-#if ENABLE_OPENCL
-    cl_mem input_mem;
-#elif ENABLE_HIP
-    vx_uint8* input_mem;
-#endif
+    void *input_mem;
     miopenTensorDescriptor_t output_desc;
-#if ENABLE_OPENCL
-    cl_mem output_mem;
-    cl_mem workspace;
-#elif ENABLE_HIP
-    vx_uint8* output_mem;
-    vx_uint8* workspace;
-#endif
+    void *output_mem;
+    void *workspace;
     size_t workspace_size;
 };
 

--- a/amd_openvx_extensions/amd_nn/src/normalization_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/normalization_layer.cpp
@@ -31,10 +31,19 @@ struct NormalizationLayerLocalData {
     double normBeta;
     double normBias;
     miopenTensorDescriptor_t input_desc;
+#if ENABLE_OPENCL
     cl_mem input_mem;
+#elif ENABLE_HIP
+    vx_uint8* input_mem;
+#endif
     miopenTensorDescriptor_t output_desc;
+#if ENABLE_OPENCL
     cl_mem output_mem;
     cl_mem workspace;
+#elif ENABLE_HIP
+    vx_uint8* output_mem;
+    vx_uint8* workspace;
+#endif
     size_t workspace_size;
 };
 
@@ -89,8 +98,13 @@ PROFILER_START(VX_NN, Normalization_Layer)
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     miopenHandle_t miopenHandle = data->handle->miopen_handle;
 
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
     float alpha = 1.0f, beta = 0.0f;
     //Apply Normalization forward.
@@ -150,9 +164,16 @@ static vx_status VX_CALLBACK initializeNormalizationLayer(vx_node node, const vx
     ERROR_CHECK_MIOPEN_STATUS(miopenCreateLRNDescriptor(&data->lrnDesc));
     ERROR_CHECK_MIOPEN_STATUS(miopenSetLRNDescriptor(data->lrnDesc, data->mode, data->normN, data->normAlpha, data->normBeta, data->normBias));
 
+
+#if ENABLE_OPENCL
     //Input and output memory.
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    //Input and output memory.
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
 #if ENABLE_DEBUG_PRINT_DIMS
     std::cout << "lrn input " << input_dims[3] << " " << input_dims[2] << " " << input_dims[1] << " " << input_dims[0] << " ";

--- a/amd_openvx_extensions/amd_nn/src/pooling_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/pooling_layer.cpp
@@ -30,15 +30,9 @@ struct PoolingLayerLocalData {
     miopenTensorDescriptor_t input_desc;
     miopenTensorDescriptor_t output_desc;
     miopenDataType_t data_type;          // data_type for the kernel
-#if ENABLE_OPENCL
-    cl_mem input_mem;
-    cl_mem output_mem;
-    cl_mem pooling_workspace;
-#elif ENABLE_HIP
-    vx_uint8* input_mem;
-    vx_uint8* output_mem;
-    vx_uint8* pooling_workspace;
-#endif
+    void *input_mem;
+    void *output_mem;
+    void *pooling_workspace;
     size_t pooling_workspace_size;
     miopenPoolingMode_t mode;
     vx_enum pad_border_mode;

--- a/amd_openvx_extensions/amd_nn/src/pooling_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/pooling_layer.cpp
@@ -30,9 +30,15 @@ struct PoolingLayerLocalData {
     miopenTensorDescriptor_t input_desc;
     miopenTensorDescriptor_t output_desc;
     miopenDataType_t data_type;          // data_type for the kernel
+#if ENABLE_OPENCL
     cl_mem input_mem;
     cl_mem output_mem;
     cl_mem pooling_workspace;
+#elif ENABLE_HIP
+    vx_uint8* input_mem;
+    vx_uint8* output_mem;
+    vx_uint8* pooling_workspace;
+#endif
     size_t pooling_workspace_size;
     miopenPoolingMode_t mode;
     vx_enum pad_border_mode;
@@ -111,8 +117,13 @@ PROFILER_START(VX_NN, Pooling_Layer)
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     miopenHandle_t miopenHandle = data->handle->miopen_handle;
 
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[7], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[7], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
     ERROR_CHECK_MIOPEN_STATUS(miopenPoolingForward(miopenHandle, data->pool_desc, &data->alpha, data->input_desc, data->input_mem, &data->beta, data->output_desc, data->output_mem, false, nullptr, 0));
 
@@ -184,9 +195,16 @@ static vx_status VX_CALLBACK initializePoolingLayer(vx_node node, const vx_refer
     ERROR_CHECK_MIOPEN_STATUS((miopenSet4dTensorDescriptor(data->input_desc, data->data_type, input_dims[3], input_dims[2], input_dims[1], input_dims[0])));
     ERROR_CHECK_MIOPEN_STATUS((miopenSet4dTensorDescriptor(data->output_desc, data->data_type, output_dims[3], output_dims[2], output_dims[1], output_dims[0])));
 
+#if ENABLE_OPENCL
     //Declare Memory.
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[7], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    //Declare Memory.
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[7], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
+
     data->alpha = 1;
     data->beta = 0;
 

--- a/amd_openvx_extensions/amd_nn/src/reshape_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/reshape_layer.cpp
@@ -26,8 +26,14 @@ THE SOFTWARE.
 #include <sys/stat.h>
 struct ReshapeLayerLocalData {
     NeuralNetworkCommonHandle * handle;
+#if ENABLE_OPENCL
     cl_mem input_mem;
     cl_mem output_mem;
+#elif ENABLE_HIP
+    vx_uint8* input_mem;
+    vx_uint8* output_mem;
+
+#endif
     vx_bool aliased;
     vx_size memsizeInBytes;
 };
@@ -72,11 +78,23 @@ PROFILER_START(VX_NN, Reshape_Layer)
     ReshapeLayerLocalData * data= NULL;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
 
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
     if (data->aliased == vx_false_e) {
+#if ENABLE_OPENCL
         ERROR_CHECK_STATUS(clEnqueueCopyBuffer(data->handle->cmdq, data->input_mem, data->output_mem, 0, 0, data->memsizeInBytes, 0, NULL, NULL));
+#elif ENABLE_HIP
+        hipError_t errcode_ret = hipMemcpyDtoD(data->output_mem, data->input_mem, data->memsizeInBytes);
+        if (errcode_ret != hipSuccess) {
+            return VX_FAILURE;
+        }
+#endif
 #if ENABLE_DEBUG_PRINT_DIMS
         std::cout << "Reshape Layer: not using aliased buffer "<< std::endl;
 #endif

--- a/amd_openvx_extensions/amd_nn/src/reshape_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/reshape_layer.cpp
@@ -82,7 +82,7 @@ PROFILER_START(VX_NN, Reshape_Layer)
 
     if (data->aliased == vx_false_e) {
 #if ENABLE_OPENCL
-        ERROR_CHECK_STATUS(clEnqueueCopyBuffer(data->handle->cmdq, *(cl_mem *)data->input_mem, *(cl_mem *)data->output_mem, 0, 0, data->memsizeInBytes, 0, NULL, NULL));
+        ERROR_CHECK_STATUS(clEnqueueCopyBuffer(data->handle->cmdq, (cl_mem)data->input_mem, (cl_mem)data->output_mem, 0, 0, data->memsizeInBytes, 0, NULL, NULL));
 #elif ENABLE_HIP
         hipError_t errcode_ret = hipMemcpyDtoD(data->output_mem, data->input_mem, data->memsizeInBytes);
         if (errcode_ret != hipSuccess) {

--- a/amd_openvx_extensions/amd_nn/src/reshape_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/reshape_layer.cpp
@@ -26,14 +26,8 @@ THE SOFTWARE.
 #include <sys/stat.h>
 struct ReshapeLayerLocalData {
     NeuralNetworkCommonHandle * handle;
-#if ENABLE_OPENCL
-    cl_mem input_mem;
-    cl_mem output_mem;
-#elif ENABLE_HIP
-    vx_uint8* input_mem;
-    vx_uint8* output_mem;
-
-#endif
+    void *input_mem;
+    void *output_mem;
     vx_bool aliased;
     vx_size memsizeInBytes;
 };
@@ -88,7 +82,7 @@ PROFILER_START(VX_NN, Reshape_Layer)
 
     if (data->aliased == vx_false_e) {
 #if ENABLE_OPENCL
-        ERROR_CHECK_STATUS(clEnqueueCopyBuffer(data->handle->cmdq, data->input_mem, data->output_mem, 0, 0, data->memsizeInBytes, 0, NULL, NULL));
+        ERROR_CHECK_STATUS(clEnqueueCopyBuffer(data->handle->cmdq, *(cl_mem *)data->input_mem, *(cl_mem *)data->output_mem, 0, 0, data->memsizeInBytes, 0, NULL, NULL));
 #elif ENABLE_HIP
         hipError_t errcode_ret = hipMemcpyDtoD(data->output_mem, data->input_mem, data->memsizeInBytes);
         if (errcode_ret != hipSuccess) {

--- a/amd_openvx_extensions/amd_nn/src/scale_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/scale_layer.cpp
@@ -167,13 +167,13 @@ static vx_status VX_CALLBACK initializeScaleLayer(vx_node node, const vx_referen
             cl_float pattern = 0;
             data->bnBias = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(float)*input_dims[2], NULL, &err);
             if (err) return VX_FAILURE;
-            err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->bnBias, &pattern, sizeof(cl_float), 0, input_dims[2], 0, NULL, NULL);
+            err = clEnqueueFillBuffer(data->handle->cmdq, (cl_mem)data->bnBias, &pattern, sizeof(cl_float), 0, input_dims[2], 0, NULL, NULL);
         }
         else {
             cl_half pattern = 0;
             data->bnBias = clCreateBuffer(context, CL_MEM_READ_WRITE, sizeof(cl_half)*input_dims[2], NULL, &err);
             if (err) return VX_FAILURE;
-            err = clEnqueueFillBuffer(data->handle->cmdq, *(cl_mem *)data->bnBias, &pattern, sizeof(cl_half), 0, input_dims[2], 0, NULL, NULL);
+            err = clEnqueueFillBuffer(data->handle->cmdq, (cl_mem)data->bnBias, &pattern, sizeof(cl_half), 0, input_dims[2], 0, NULL, NULL);
         }
         if (err) return VX_FAILURE;
 #elif ENABLE_HIP
@@ -234,7 +234,7 @@ static vx_status VX_CALLBACK uninitializeScaleLayer(vx_node node, const vx_refer
         if(!parameters[2]){
             if(data->bnBias) {
 #if ENABLE_OPENCL
-                cl_int err = clReleaseMemObject(*(cl_mem *)data->bnBias);
+                cl_int err = clReleaseMemObject((cl_mem)data->bnBias);
                 if (err) return VX_FAILURE;
 #elif ENABLE_HIP
                 hipError_t errcode_ret = hipFree(data->bnBias);

--- a/amd_openvx_extensions/amd_nn/src/scale_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/scale_layer.cpp
@@ -192,10 +192,6 @@ static vx_status VX_CALLBACK initializeScaleLayer(vx_node node, const vx_referen
             return VX_FAILURE;
         }
         hipError_t errcode_ret = hipSuccess;
-        errcode_ret = hipSetDevice(hip_device);
-        if (errcode_ret != hipSuccess) {
-            return VX_FAILURE;
-        }
         if (data_type == miopenFloat) {
             errcode_ret = hipMalloc(&data->bnBias, sizeof(float) * input_dims[2]);
             if (errcode_ret != hipSuccess) {

--- a/amd_openvx_extensions/amd_nn/src/scale_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/scale_layer.cpp
@@ -151,7 +151,11 @@ static vx_status VX_CALLBACK initializeScaleLayer(vx_node node, const vx_referen
 #endif
 
     if(parameters[2]){
+#if ENABLE_OPENCL
         ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_OPENCL, &data->bnBias, sizeof(data->bnBias)));
+#elif ENABLE_HIP
+        ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &data->bnBias, sizeof(data->bnBias)));
+#endif
     }
     else{
         vx_context   vxContext = vxGetContext((vx_reference)node);

--- a/amd_openvx_extensions/amd_nn/src/softmax_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/softmax_layer.cpp
@@ -28,9 +28,18 @@ struct SoftmaxLayerLocalData {
     float beta;
     miopenDataType_t data_type;          // data_type for the kernel
     miopenTensorDescriptor_t input_desc;
+#if ENABLE_OPENCL
     cl_mem input_mem;
+#elif ENABLE_HIP
+    vx_uint8* input_mem;
+#endif
     miopenTensorDescriptor_t output_desc;
+#if ENABLE_OPENCL
     cl_mem output_mem;
+#elif ENABLE_HIP
+    vx_uint8* output_mem;
+#endif
+
     int dim_in;
     int dim_out;
     vx_int32 axis;
@@ -81,11 +90,16 @@ PROFILER_START(VX_NN, Softmax_Layer)
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     miopenHandle_t miopenHandle = data->handle->miopen_handle;
 
+
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
     ERROR_CHECK_STATUS(miopenSoftmaxForward(miopenHandle, &data->alpha, data->input_desc, data->input_mem, &data->beta, data->output_desc, data->output_mem));
-
 
 
     /*DUMP LAYER BUFFER*/
@@ -133,10 +147,15 @@ static vx_status VX_CALLBACK initializeSoftmaxLayer(vx_node node, const vx_refer
         ERROR_CHECK_MIOPEN_STATUS(miopenSet4dTensorDescriptor(data->input_desc, data->data_type, input_dims[3]*input_dims[2], input_dims[1], input_dims[0], 1));
         ERROR_CHECK_MIOPEN_STATUS(miopenSet4dTensorDescriptor(data->output_desc, data->data_type, output_dims[3]*output_dims[2], output_dims[1], output_dims[0],1));
     }
-    
+
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input_mem, sizeof(data->input_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
-    
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input_mem, sizeof(data->input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
+
     data->alpha = 1;
     data->beta = 0;
 

--- a/amd_openvx_extensions/amd_nn/src/softmax_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/softmax_layer.cpp
@@ -28,18 +28,9 @@ struct SoftmaxLayerLocalData {
     float beta;
     miopenDataType_t data_type;          // data_type for the kernel
     miopenTensorDescriptor_t input_desc;
-#if ENABLE_OPENCL
-    cl_mem input_mem;
-#elif ENABLE_HIP
-    vx_uint8* input_mem;
-#endif
+    void *input_mem;
     miopenTensorDescriptor_t output_desc;
-#if ENABLE_OPENCL
-    cl_mem output_mem;
-#elif ENABLE_HIP
-    vx_uint8* output_mem;
-#endif
-
+    void *output_mem;
     int dim_in;
     int dim_out;
     vx_int32 axis;

--- a/amd_openvx_extensions/amd_nn/src/tensor_add.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tensor_add.cpp
@@ -29,23 +29,11 @@ struct TensorAddLocalData {
     float alpha2;
     float beta;
     miopenTensorDescriptor_t input1;
-#if ENABLE_OPENCL
-    cl_mem input1_mem;
-#elif ENABLE_HIP
-    vx_uint8* input1_mem;
-#endif
+    void *input1_mem;
     miopenTensorDescriptor_t input2;
-#if ENABLE_OPENCL
-    cl_mem input2_mem;
-#elif ENABLE_HIP
-    vx_uint8* input2_mem;
-#endif
+    void *input2_mem;
     miopenTensorDescriptor_t output;
-#if ENABLE_OPENCL
-    cl_mem output_mem;
-#elif ENABLE_HIP
-    vx_uint8* output_mem;
-#endif
+    void *output_mem;
 };
 
 static vx_status VX_CALLBACK validateTensorAddition(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])

--- a/amd_openvx_extensions/amd_nn/src/tensor_add.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tensor_add.cpp
@@ -29,11 +29,23 @@ struct TensorAddLocalData {
     float alpha2;
     float beta;
     miopenTensorDescriptor_t input1;
+#if ENABLE_OPENCL
     cl_mem input1_mem;
+#elif ENABLE_HIP
+    vx_uint8* input1_mem;
+#endif
     miopenTensorDescriptor_t input2;
+#if ENABLE_OPENCL
     cl_mem input2_mem;
+#elif ENABLE_HIP
+    vx_uint8* input2_mem;
+#endif
     miopenTensorDescriptor_t output;
+#if ENABLE_OPENCL
     cl_mem output_mem;
+#elif ENABLE_HIP
+    vx_uint8* output_mem;
+#endif
 };
 
 static vx_status VX_CALLBACK validateTensorAddition(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])
@@ -92,9 +104,15 @@ PROFILER_START(VX_NN, Tensor_Add_Layer)
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     miopenHandle_t miopenHandle = data->handle->miopen_handle;
 
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input1_mem, sizeof(data->input1_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->input2_mem, sizeof(data->input2_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input1_mem, sizeof(data->input1_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->input2_mem, sizeof(data->input2_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
     //miopen elementwise addition call.
     ERROR_CHECK_MIOPEN_STATUS(miopenOpTensor(miopenHandle, data->operation, &data->alpha1, data->input1, data->input1_mem, &data->alpha2, data->input2, data->input2_mem, &data->beta, data->output, data->output_mem));
@@ -140,10 +158,17 @@ static vx_status VX_CALLBACK initializeTensorAddition(vx_node node, const vx_ref
     data->beta = 0;
     data->operation = miopenTensorOpAdd;
 
+#if ENABLE_OPENCL
     //input and output memory.
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input1_mem, sizeof(data->input1_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->input2_mem, sizeof(data->input2_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    //input and output memory.
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input1_mem, sizeof(data->input1_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->input2_mem, sizeof(data->input2_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
 #if ENABLE_DEBUG_PRINT_DIMS
     std::cout << "tensor_add input1 " << input1_dims[3] << " " << input1_dims[2] << " " << input1_dims[1] << " " << input1_dims[0] << " ";

--- a/amd_openvx_extensions/amd_nn/src/tensor_image_converter.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tensor_image_converter.cpp
@@ -227,17 +227,34 @@ static vx_status VX_CALLBACK host_kernel(vx_node node, const vx_reference * para
     vx_uint32 height = (vx_uint32)input_dims[1];
     vx_uint32 N = (vx_uint32)input_dims[3];
 
-    AgoData *input  = reinterpret_cast<AgoData *>(parameters[0]);
-    AgoData *output = reinterpret_cast<AgoData *>(parameters[1]);
-    AgoData *sc1 = reinterpret_cast<AgoData *>(parameters[2]);
-    AgoData *sc2 = reinterpret_cast<AgoData *>(parameters[3]);
-    AgoData *reverse_channel_order = reinterpret_cast<AgoData *>(parameters[4]);
+    vx_size temp[4] = {0};
+    uint4 input_stride;
+    vx_size in_offset;
+    vx_uint32 output_offset, output_stride;
+    unsigned char *input_mem = NULL;
+    unsigned char *output_mem = NULL;
+    float sc1, sc2;
+    uint reverse_channel_order;
+    hipStream_t hip_stream;
 
-    uint4 input_stride = make_uint4((uint)input->u.tensor.stride[0], (uint)input->u.tensor.stride[1],
-                                     (uint)input->u.tensor.stride[2], (uint)input->u.tensor.stride[3]);
+    ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_ATTRIBUTE_AMD_HIP_STREAM, &hip_stream, sizeof(hip_stream)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &input_mem, sizeof(input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_OFFSET_OPENCL, &in_offset, sizeof(in_offset)));
+    ERROR_CHECK_STATUS(vxQueryImage((vx_image)parameters[1], VX_IMAGE_ATTRIBUTE_AMD_HIP_BUFFER, &output_mem, sizeof(output_mem)));
+    ERROR_CHECK_STATUS(vxQueryImage((vx_image)parameters[1], VX_IMAGE_ATTRIBUTE_AMD_GPU_BUFFER_OFFSET, &output_offset, sizeof(output_offset)));
+    ERROR_CHECK_STATUS(vxQueryImage((vx_image)parameters[1], VX_IMAGE_ATTRIBUTE_AMD_GPU_BUFFER_STRIDE, &output_stride, sizeof(output_stride)));
+    ERROR_CHECK_STATUS(vxReadScalarValue((vx_scalar)parameters[2], &sc1));
+    ERROR_CHECK_STATUS(vxReadScalarValue((vx_scalar)parameters[3], &sc2));
+    ERROR_CHECK_STATUS(vxReadScalarValue((vx_scalar)parameters[4], &reverse_channel_order));
 
-    if (HipExec_tensor_to_image_layer(node->hip_stream0, format, type, width, height, N, input->hip_memory, input->u.tensor.offset, input_stride,
-        output->hip_memory, output->gpu_buffer_offset, output->u.img.stride_in_bytes, sc1->u.scalar.u.f, sc2->u.scalar.u.f, reverse_channel_order->u.scalar.u.u)) {
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_STRIDE_OPENCL, temp, sizeof(temp)));
+    input_stride.x = temp[0];
+    input_stride.y = temp[1];
+    input_stride.z = temp[2];
+    input_stride.w = temp[3];
+
+    if (HipExec_tensor_to_image_layer(hip_stream, format, type, width, height, N, input_mem, in_offset, input_stride,
+        output_mem, output_offset, output_stride, sc1, sc2, reverse_channel_order)) {
         return VX_FAILURE;
     }
 

--- a/amd_openvx_extensions/amd_nn/src/tensor_matrix_multiply.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tensor_matrix_multiply.cpp
@@ -21,7 +21,9 @@ THE SOFTWARE.
 */
 
 #include "kernels.h"
+#if ENABLE_OPENCL
 #include <miopengemm/gemm.hpp>
+#endif
 #include <algorithm>
 
 struct LocalData {
@@ -33,9 +35,14 @@ struct LocalData {
     size_t i_offset, ldi;
     size_t c_offset, ldc;
     int ID;
+#if ENABLE_OPENCL
     cl_kernel copy_kernel;
     size_t copy_global[3];
     size_t copy_local[3];
+#elif ENABLE_HIP
+    vx_enum type;
+    vx_size width, height;
+#endif
 };
 
 static vx_status VX_CALLBACK validate(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])
@@ -239,6 +246,7 @@ static vx_status VX_CALLBACK initialize(vx_node node, const vx_reference *parame
         data->ldi = i_stride[data->tI ? 2 : 1] >> 2;
     }
 
+#if ENABLE_OPENCL
     // input and output memory
     cl_mem input1_mem = nullptr, input2_mem = nullptr, input3_mem = nullptr, output_mem = nullptr;
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &input1_mem, sizeof(cl_mem)));
@@ -354,7 +362,6 @@ static vx_status VX_CALLBACK initialize(vx_node node, const vx_reference *parame
         ERROR_CHECK_STATUS(clEnqueueNDRangeKernel(data->handle->cmdq, data->copy_kernel, 3, nullptr, data->copy_global, data->copy_local, 0, nullptr, nullptr));
         ERROR_CHECK_STATUS(clFinish(data->handle->cmdq));
     }
-
     // build and save ID
     MIOpenGEMM::GemmStatus status =
         MIOpenGEMM::xgemm<float>(false, data->tA, data->tB, data->m, data->n, data->k,
@@ -371,6 +378,29 @@ static vx_status VX_CALLBACK initialize(vx_node node, const vx_reference *parame
     }
     ERROR_CHECK_STATUS(clFinish(data->handle->cmdq));
     data->ID = status.ID;
+#elif ENABLE_HIP
+    // input and output memory
+    vx_uint8 *input1_mem = nullptr, *input2_mem = nullptr, *input3_mem = nullptr, *output_mem = nullptr;
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &input1_mem, sizeof(input1_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &input2_mem, sizeof(input2_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[4], VX_TENSOR_BUFFER_HIP, &output_mem, sizeof(output_mem)));
+    if(parameters[2]) {
+        ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &input3_mem, sizeof(input3_mem)));
+    }
+    data->type = type;
+    data->width = input3_dims[0];
+    data->height = input3_dims[1];
+    // if input3 is available, launch HIP kernel for copy/transpose
+    if(parameters[2]) {
+        if (HipExec_copy(node->hip_stream0, data->type, input3_mem, output_mem, data->width, data->height, data->ldi, data->i_offset,
+            data->ldc, data->c_offset, data->tI)) {
+            return VX_FAILURE;
+        }
+        hipStreamSynchronize(node->hip_stream0);
+
+        // TODO - call rocBLAS to do gemm
+    }
+#endif
 
     // save local data ptr as node attribute
     ERROR_CHECK_STATUS(vxSetNodeAttribute(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
@@ -381,9 +411,10 @@ static vx_status VX_CALLBACK process(vx_node node, const vx_reference * paramete
 {
     // get parameters and buffers
     LocalData * data = nullptr;
-    cl_mem input1_mem = nullptr, input2_mem = nullptr, input3_mem = nullptr, output_mem = nullptr;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     if(!data) return VX_FAILURE;
+#if ENABLE_OPENCL
+    cl_mem input1_mem = nullptr, input2_mem = nullptr, input3_mem = nullptr, output_mem = nullptr;
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &input1_mem, sizeof(cl_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &input2_mem, sizeof(cl_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[4], VX_TENSOR_BUFFER_OPENCL, &output_mem, sizeof(cl_mem)));
@@ -394,7 +425,6 @@ static vx_status VX_CALLBACK process(vx_node node, const vx_reference * paramete
         ERROR_CHECK_STATUS(clSetKernelArg(data->copy_kernel, 1, sizeof(cl_mem), &output_mem));
         ERROR_CHECK_STATUS(clEnqueueNDRangeKernel(data->handle->cmdq, data->copy_kernel, 3, nullptr, data->copy_global, data->copy_local, 0, nullptr, nullptr));
     }
-
     // run GEMM
     MIOpenGEMM::GemmStatus status =
         MIOpenGEMM::xgemm<float>(false, data->tA, data->tB, data->m, data->n, data->k, 1.0f,
@@ -406,6 +436,21 @@ static vx_status VX_CALLBACK process(vx_node node, const vx_reference * paramete
     if(!status.success) {
         return VX_FAILURE;
     }
+#elif ENABLE_HIP
+    vx_uint8 *input1_mem = nullptr, *input2_mem = nullptr, *input3_mem = nullptr, *output_mem = nullptr;
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &input1_mem, sizeof(vx_uint8)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &input2_mem, sizeof(vx_uint8)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[4], VX_TENSOR_BUFFER_HIP, &output_mem, sizeof(vx_uint8)));
+    if(parameters[2]) {
+        ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &input3_mem, sizeof(vx_uint8)));
+        // copy/transpose input3 to output
+        if (HipExec_copy(node->hip_stream0, data->type, input3_mem, output_mem, data->width, data->height, data->ldi, data->i_offset,
+            data->ldc, data->c_offset, data->tI)) {
+            return VX_FAILURE;
+        }
+    }
+    // TODO - use rocBLAS to run GEMM
+#endif
 
     return VX_SUCCESS;
 }
@@ -415,9 +460,11 @@ static vx_status VX_CALLBACK uninitialize(vx_node node, const vx_reference *para
     LocalData * data = nullptr;
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     if (data) {
+#if ENABLE_OPENCL
         if(data->copy_kernel) {
             clReleaseKernel(data->copy_kernel);
         }
+#endif
         ERROR_CHECK_STATUS(releaseGraphHandle(node, data->handle));
         delete data;
     }

--- a/amd_openvx_extensions/amd_nn/src/tensor_max.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tensor_max.cpp
@@ -29,11 +29,24 @@ struct TensorMaxLocalData {
     float alpha2;
     float beta;
     miopenTensorDescriptor_t input1;
+#if ENABLE_OPENCL
     cl_mem input1_mem;
+#elif ENABLE_HIP
+    vx_uint8* input1_mem;
+#endif
     miopenTensorDescriptor_t input2;
+#if ENABLE_OPENCL
     cl_mem input2_mem;
+#elif ENABLE_HIP
+    vx_uint8* input2_mem;
+#endif
     miopenTensorDescriptor_t output;
+#if ENABLE_OPENCL
     cl_mem output_mem;
+#elif ENABLE_HIP
+    vx_uint8* output_mem;
+#endif
+
 };
 
 static vx_status VX_CALLBACK validateTensorMax(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])
@@ -91,9 +104,15 @@ static vx_status VX_CALLBACK processTensorMax(vx_node node, const vx_reference *
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     miopenHandle_t miopenHandle = data->handle->miopen_handle;
 
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input1_mem, sizeof(data->input1_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->input2_mem, sizeof(data->input2_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input1_mem, sizeof(data->input1_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->input2_mem, sizeof(data->input2_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
     //miopen elementwise max call.
     ERROR_CHECK_MIOPEN_STATUS(miopenOpTensor(miopenHandle, data->operation, &data->alpha1, data->input1, data->input1_mem, &data->alpha2, data->input2, data->input2_mem, &data->beta, data->output, data->output_mem));
@@ -130,10 +149,17 @@ static vx_status VX_CALLBACK initializeTensorMax(vx_node node, const vx_referenc
     data->beta = 0;
     data->operation = miopenTensorOpMax;
 
+#if ENABLE_OPENCL
     //input and output memory.
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input1_mem, sizeof(data->input1_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->input2_mem, sizeof(data->input2_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    //input and output memory.
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input1_mem, sizeof(data->input1_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->input2_mem, sizeof(data->input2_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
 #if ENABLE_DEBUG_PRINT_DIMS
     std::cout << "tensor_max input1 " << input1_dims[3] << " " << input1_dims[2] << " " << input1_dims[1] << " " << input1_dims[0] << " ";

--- a/amd_openvx_extensions/amd_nn/src/tensor_max.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tensor_max.cpp
@@ -29,23 +29,11 @@ struct TensorMaxLocalData {
     float alpha2;
     float beta;
     miopenTensorDescriptor_t input1;
-#if ENABLE_OPENCL
-    cl_mem input1_mem;
-#elif ENABLE_HIP
-    vx_uint8* input1_mem;
-#endif
+    void *input1_mem;
     miopenTensorDescriptor_t input2;
-#if ENABLE_OPENCL
-    cl_mem input2_mem;
-#elif ENABLE_HIP
-    vx_uint8* input2_mem;
-#endif
+    void *input2_mem;
     miopenTensorDescriptor_t output;
-#if ENABLE_OPENCL
-    cl_mem output_mem;
-#elif ENABLE_HIP
-    vx_uint8* output_mem;
-#endif
+    void *output_mem;
 
 };
 

--- a/amd_openvx_extensions/amd_nn/src/tensor_min.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tensor_min.cpp
@@ -29,11 +29,23 @@ struct TensorMinLocalData {
     float alpha2;
     float beta;
     miopenTensorDescriptor_t input1;
+#if ENABLE_OPENCL
     cl_mem input1_mem;
+#elif ENABLE_HIP
+    vx_uint8* input1_mem;
+#endif
     miopenTensorDescriptor_t input2;
+#if ENABLE_OPENCL
     cl_mem input2_mem;
+#elif ENABLE_HIP
+    vx_uint8* input2_mem;
+#endif
     miopenTensorDescriptor_t output;
+#if ENABLE_OPENCL
     cl_mem output_mem;
+#elif ENABLE_HIP
+    vx_uint8* output_mem;
+#endif
 };
 
 static vx_status VX_CALLBACK validateTensorMin(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])
@@ -91,9 +103,15 @@ static vx_status VX_CALLBACK processTensorMin(vx_node node, const vx_reference *
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     miopenHandle_t miopenHandle = data->handle->miopen_handle;
 
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input1_mem, sizeof(data->input1_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->input2_mem, sizeof(data->input2_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input1_mem, sizeof(data->input1_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->input2_mem, sizeof(data->input2_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
     //miopen elementwise min call.
     ERROR_CHECK_MIOPEN_STATUS(miopenOpTensor(miopenHandle, data->operation, &data->alpha1, data->input1, data->input1_mem, &data->alpha2, data->input2, data->input2_mem, &data->beta, data->output, data->output_mem));
@@ -130,10 +148,17 @@ static vx_status VX_CALLBACK initializeTensorMin(vx_node node, const vx_referenc
     data->beta = 0;
     data->operation = miopenTensorOpMin;
 
+#if ENABLE_OPENCL
     //input and output memory.
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input1_mem, sizeof(data->input1_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->input2_mem, sizeof(data->input2_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    //input and output memory.
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input1_mem, sizeof(data->input1_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->input2_mem, sizeof(data->input2_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
 #if ENABLE_DEBUG_PRINT_DIMS
     std::cout << "tensor_min input1 " << input1_dims[3] << " " << input1_dims[2] << " " << input1_dims[1] << " " << input1_dims[0] << " ";

--- a/amd_openvx_extensions/amd_nn/src/tensor_min.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tensor_min.cpp
@@ -29,23 +29,11 @@ struct TensorMinLocalData {
     float alpha2;
     float beta;
     miopenTensorDescriptor_t input1;
-#if ENABLE_OPENCL
-    cl_mem input1_mem;
-#elif ENABLE_HIP
-    vx_uint8* input1_mem;
-#endif
+    void *input1_mem;
     miopenTensorDescriptor_t input2;
-#if ENABLE_OPENCL
-    cl_mem input2_mem;
-#elif ENABLE_HIP
-    vx_uint8* input2_mem;
-#endif
+    void *input2_mem;
     miopenTensorDescriptor_t output;
-#if ENABLE_OPENCL
-    cl_mem output_mem;
-#elif ENABLE_HIP
-    vx_uint8* output_mem;
-#endif
+    void *output_mem;
 };
 
 static vx_status VX_CALLBACK validateTensorMin(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])

--- a/amd_openvx_extensions/amd_nn/src/tensor_multiply.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tensor_multiply.cpp
@@ -29,11 +29,23 @@ struct TensorMultiplyLocalData {
     float alpha2;
     float beta;
     miopenTensorDescriptor_t input1;
+#if ENABLE_OPENCL
     cl_mem input1_mem;
+#elif ENABLE_HIP
+    vx_uint8* input1_mem;
+#endif
     miopenTensorDescriptor_t input2;
+#if ENABLE_OPENCL
     cl_mem input2_mem;
+#elif ENABLE_HIP
+    vx_uint8* input2_mem;
+#endif
     miopenTensorDescriptor_t output;
+#if ENABLE_OPENCL
     cl_mem output_mem;
+#elif ENABLE_HIP
+    vx_uint8* output_mem;
+#endif
 };
 
 static vx_status VX_CALLBACK validateTensorMultiply(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])
@@ -96,9 +108,15 @@ PROFILER_START(VX_NN, Tensor_Multiply_Layer)
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     miopenHandle_t miopenHandle = data->handle->miopen_handle;
 
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input1_mem, sizeof(data->input1_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->input2_mem, sizeof(data->input2_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input1_mem, sizeof(data->input1_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->input2_mem, sizeof(data->input2_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
     //miopen multiply call.
     ERROR_CHECK_MIOPEN_STATUS(miopenOpTensor(miopenHandle, data->operation, &data->alpha1, data->input1, data->input1_mem, &data->alpha2, data->input2, data->input2_mem, &data->beta, data->output, data->output_mem));
@@ -136,10 +154,17 @@ static vx_status VX_CALLBACK initializeTensorMultiply(vx_node node, const vx_ref
     data->beta = 0;
     data->operation = miopenTensorOpMul;
 
+#if ENABLE_OPENCL
     //input and output memory.
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input1_mem, sizeof(data->input1_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->input2_mem, sizeof(data->input2_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    //input and output memory.
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input1_mem, sizeof(data->input1_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->input2_mem, sizeof(data->input2_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[5], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
 #if ENABLE_DEBUG_PRINT_DIMS
     std::cout << "tensor_multiply input1 " << input1_dims[3] << " " << input1_dims[2] << " " << input1_dims[1] << " " << input1_dims[0] << " ";

--- a/amd_openvx_extensions/amd_nn/src/tensor_multiply.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tensor_multiply.cpp
@@ -29,23 +29,11 @@ struct TensorMultiplyLocalData {
     float alpha2;
     float beta;
     miopenTensorDescriptor_t input1;
-#if ENABLE_OPENCL
-    cl_mem input1_mem;
-#elif ENABLE_HIP
-    vx_uint8* input1_mem;
-#endif
+    void *input1_mem;
     miopenTensorDescriptor_t input2;
-#if ENABLE_OPENCL
-    cl_mem input2_mem;
-#elif ENABLE_HIP
-    vx_uint8* input2_mem;
-#endif
+    void *input2_mem;
     miopenTensorDescriptor_t output;
-#if ENABLE_OPENCL
-    cl_mem output_mem;
-#elif ENABLE_HIP
-    vx_uint8* output_mem;
-#endif
+    void *output_mem;
 };
 
 static vx_status VX_CALLBACK validateTensorMultiply(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])

--- a/amd_openvx_extensions/amd_nn/src/tensor_subtract.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tensor_subtract.cpp
@@ -29,23 +29,11 @@ struct TensorSubLocalData {
     float alpha2;
     float beta;
     miopenTensorDescriptor_t input1;
-#if ENABLE_OPENCL
-    cl_mem input1_mem;
-#elif ENABLE_HIP
-    vx_uint8* input1_mem;
-#endif
+    void *input1_mem;
     miopenTensorDescriptor_t input2;
-#if ENABLE_OPENCL
-    cl_mem input2_mem;
-#elif ENABLE_HIP
-    vx_uint8* input2_mem;
-#endif
+    void *input2_mem;
     miopenTensorDescriptor_t output;
-#if ENABLE_OPENCL
-    cl_mem output_mem;
-#elif ENABLE_HIP
-    vx_uint8* output_mem;
-#endif
+    void *output_mem;
 };
 
 static vx_status VX_CALLBACK validateTensorSub(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])

--- a/amd_openvx_extensions/amd_nn/src/tensor_subtract.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tensor_subtract.cpp
@@ -29,11 +29,23 @@ struct TensorSubLocalData {
     float alpha2;
     float beta;
     miopenTensorDescriptor_t input1;
+#if ENABLE_OPENCL
     cl_mem input1_mem;
+#elif ENABLE_HIP
+    vx_uint8* input1_mem;
+#endif
     miopenTensorDescriptor_t input2;
+#if ENABLE_OPENCL
     cl_mem input2_mem;
+#elif ENABLE_HIP
+    vx_uint8* input2_mem;
+#endif
     miopenTensorDescriptor_t output;
+#if ENABLE_OPENCL
     cl_mem output_mem;
+#elif ENABLE_HIP
+    vx_uint8* output_mem;
+#endif
 };
 
 static vx_status VX_CALLBACK validateTensorSub(vx_node node, const vx_reference parameters[], vx_uint32 num, vx_meta_format metas[])
@@ -92,9 +104,16 @@ PROFILER_START(VX_NN, Tensor_Substract_Layer)
     ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_LOCAL_DATA_PTR, &data, sizeof(data)));
     miopenHandle_t miopenHandle = data->handle->miopen_handle;
 
+#if ENABLE_OPENCL
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input1_mem, sizeof(data->input1_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->input2_mem, sizeof(data->input2_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input1_mem, sizeof(data->input1_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->input2_mem, sizeof(data->input2_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
+
 
     //miopen elementwise addition call.
     ERROR_CHECK_MIOPEN_STATUS(miopenOpTensor(miopenHandle, data->operation, &data->alpha1, data->input1, data->input1_mem, &data->alpha2, data->input2, data->input2_mem, &data->beta, data->output, data->output_mem));
@@ -141,10 +160,17 @@ static vx_status VX_CALLBACK initializeTensorSub(vx_node node, const vx_referenc
     data->beta = 0;
     data->operation = miopenTensorOpAdd;
 
+#if ENABLE_OPENCL
     //input and output memory.
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_OPENCL, &data->input1_mem, sizeof(data->input1_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_OPENCL, &data->input2_mem, sizeof(data->input2_mem)));
     ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_OPENCL, &data->output_mem, sizeof(data->output_mem)));
+#elif ENABLE_HIP
+    //input and output memory.
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &data->input1_mem, sizeof(data->input1_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &data->input2_mem, sizeof(data->input2_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[3], VX_TENSOR_BUFFER_HIP, &data->output_mem, sizeof(data->output_mem)));
+#endif
 
 #if ENABLE_DEBUG_PRINT_DIMS
     std::cout << "tensor_sub input1 " << input1_dims[3] << " " << input1_dims[2] << " " << input1_dims[1] << " " << input1_dims[0] << " ";

--- a/amd_openvx_extensions/amd_nn/src/tile_layer.cpp
+++ b/amd_openvx_extensions/amd_nn/src/tile_layer.cpp
@@ -147,23 +147,43 @@ static vx_status VX_CALLBACK host_kernel(vx_node node, const vx_reference * para
     globalThreads.y = output_dims[1];
     globalThreads.z = output_dims[2] * output_dims[3];
 
-    AgoData *input  = reinterpret_cast<AgoData *>(parameters[0]);
-    AgoData *repeat = reinterpret_cast<AgoData *>(parameters[1]);
-    AgoData *output = reinterpret_cast<AgoData *>(parameters[2]);
-
-    uint4 input_stride = make_uint4((uint)input->u.tensor.stride[0], (uint)input->u.tensor.stride[1],
-                                    (uint)input->u.tensor.stride[2], (uint)input->u.tensor.stride[3]);
-
+    vx_size temp[4] = {0};
+    uint4 input_stride, repeat_stride, output_stride;
+    vx_size in_offset, repeat_offset, output_offset;
+    unsigned char *input_mem = NULL;
+    unsigned char *repeat_mem = NULL;
+    unsigned char *output_mem = NULL;
+    hipStream_t hip_stream;
     uint4 input_dimensions = make_uint4((uint)input_dims[0], (uint)input_dims[1], (uint)input_dims[2], (uint)input_dims[3]);
 
-    uint4 repeat_stride = make_uint4((uint)repeat->u.tensor.stride[0], (uint)repeat->u.tensor.stride[1],
-                                     (uint)repeat->u.tensor.stride[2], (uint)repeat->u.tensor.stride[3]);
+    ERROR_CHECK_STATUS(vxQueryNode(node, VX_NODE_ATTRIBUTE_AMD_HIP_STREAM, &hip_stream, sizeof(hip_stream)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_BUFFER_HIP, &input_mem, sizeof(input_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_OFFSET_OPENCL, &in_offset, sizeof(in_offset)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_BUFFER_HIP, &repeat_mem, sizeof(repeat_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_OFFSET_OPENCL, &repeat_offset, sizeof(repeat_offset)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_BUFFER_HIP, &output_mem, sizeof(output_mem)));
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_OFFSET_OPENCL, &output_offset, sizeof(output_offset)));
 
-    uint4 output_stride = make_uint4((uint)output->u.tensor.stride[0], (uint)output->u.tensor.stride[1],
-                                     (uint)output->u.tensor.stride[2], (uint)output->u.tensor.stride[3]);
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[0], VX_TENSOR_STRIDE_OPENCL, temp, sizeof(temp)));
+    input_stride.x = temp[0];
+    input_stride.y = temp[1];
+    input_stride.z = temp[2];
+    input_stride.w = temp[3];
 
-    if (HipExec_Tile_layer(node->hip_stream0, globalThreads, dim3(1), type, input->hip_memory, input->u.tensor.offset, input_stride,
-        input_dimensions, repeat->hip_memory, repeat->u.tensor.offset, repeat_stride, output->hip_memory, output->u.tensor.offset, output_stride)) {
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[1], VX_TENSOR_STRIDE_OPENCL, temp, sizeof(temp)));
+    repeat_stride.x = temp[0];
+    repeat_stride.y = temp[1];
+    repeat_stride.z = temp[2];
+    repeat_stride.w = temp[3];
+
+    ERROR_CHECK_STATUS(vxQueryTensor((vx_tensor)parameters[2], VX_TENSOR_STRIDE_OPENCL, temp, sizeof(temp)));
+    output_stride.x = temp[0];
+    output_stride.y = temp[1];
+    output_stride.z = temp[2];
+    output_stride.w = temp[3];
+
+    if (HipExec_Tile_layer(hip_stream, globalThreads, dim3(1), type, input_mem, in_offset, input_stride,
+        input_dimensions, repeat_mem, repeat_offset, repeat_stride, output_mem, output_offset, output_stride)) {
         return VX_FAILURE;
     }
 
@@ -190,7 +210,7 @@ vx_status publishTileLayer(vx_context context) {
     ERROR_CHECK_STATUS(vxAddParameterToKernel(kernel, 0, VX_INPUT, VX_TYPE_TENSOR, VX_PARAMETER_STATE_REQUIRED));
     ERROR_CHECK_STATUS(vxAddParameterToKernel(kernel, 1, VX_INPUT, VX_TYPE_TENSOR, VX_PARAMETER_STATE_REQUIRED));
     ERROR_CHECK_STATUS(vxAddParameterToKernel(kernel, 2, VX_OUTPUT, VX_TYPE_TENSOR, VX_PARAMETER_STATE_REQUIRED));
-    
+
     ERROR_CHECK_STATUS(vxFinalizeKernel(kernel));
     ERROR_CHECK_STATUS(vxReleaseKernel(&kernel));
     return VX_SUCCESS; 


### PR DESCRIPTION
- This PR adds support for NN layers that call MIOpen. These include convolution, deconvolution, fully_connected, 
local_response_normalization, normalization, pooling, reshape, scale, softmax, tensor_add, tensor_max, tensor_min, tensor_multiply, 
 and tensor_subtract layers.

- This PR has partial support for tensor_matrix_multiply. We would need to use rocBLAS for doing GEMM which will be added in the next PR for this layer.