### PR TITLE
OpenVX HIP GPU backend - fix failures reported in issue #566 for HIP backend

### DIFF
--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -18428,7 +18428,7 @@ int agoKernel_Remap_U8_U8_Bilinear(AgoNode * node, AgoKernelCommand cmd)
             node->hip_stream0, oImg->u.img.width, oImg->u.img.height,
             oImg->hip_memory + oImg->gpu_buffer_offset,oImg->u.img.stride_in_bytes,
             iImg->u.img.width, iImg->u.img.height,
-            iImg->hip_memory + iImg->gpu_buffer_offset, iImg->u.img.stride_in_bytes,
+            iImg->hip_memory + iImg->gpu_buffer_offset, iImg->u.img.stride_in_bytes, iImg->size,
             (ago_coord2d_ushort_t *)iMap->hip_memory,
             iMap->u.remap.dst_width * sizeof(ago_coord2d_ushort_t))) {
             status = VX_FAILURE;
@@ -19010,7 +19010,7 @@ int agoKernel_WarpAffine_U8_U8_Nearest(AgoNode * node, AgoKernelCommand cmd)
             oImg->hip_memory + oImg->gpu_buffer_offset,oImg->u.img.stride_in_bytes,
             iImg->u.img.width, iImg->u.img.height,
             iImg->hip_memory + iImg->gpu_buffer_offset, iImg->u.img.stride_in_bytes,
-            (ago_affine_matrix_t *)(iMat->hip_memory + iMat->gpu_buffer_offset))) {
+            iImg->size, (ago_affine_matrix_t *)(iMat->hip_memory + iMat->gpu_buffer_offset))) {
             status = VX_FAILURE;
         }
     }
@@ -19222,7 +19222,7 @@ int agoKernel_WarpAffine_U8_U8_Bilinear(AgoNode * node, AgoKernelCommand cmd)
             oImg->hip_memory + oImg->gpu_buffer_offset,oImg->u.img.stride_in_bytes,
             iImg->u.img.width, iImg->u.img.height,
             iImg->hip_memory + iImg->gpu_buffer_offset, iImg->u.img.stride_in_bytes,
-            (ago_affine_matrix_t *)(iMat->hip_memory + iMat->gpu_buffer_offset))) {
+            iImg->size, (ago_affine_matrix_t *)(iMat->hip_memory + iMat->gpu_buffer_offset))) {
             status = VX_FAILURE;
         }
     }
@@ -19419,7 +19419,7 @@ int agoKernel_WarpPerspective_U8_U8_Nearest(AgoNode * node, AgoKernelCommand cmd
             node->hip_stream0, oImg->u.img.width, oImg->u.img.height,
             oImg->hip_memory + oImg->gpu_buffer_offset,oImg->u.img.stride_in_bytes,
             iImg->u.img.width, iImg->u.img.height,
-            iImg->hip_memory + iImg->gpu_buffer_offset, iImg->u.img.stride_in_bytes,
+            iImg->hip_memory + iImg->gpu_buffer_offset, iImg->u.img.stride_in_bytes, iImg->size,
             (ago_perspective_matrix_t *)(iMat->hip_memory + iMat->gpu_buffer_offset))) {
             status = VX_FAILURE;
         }
@@ -19634,7 +19634,7 @@ int agoKernel_WarpPerspective_U8_U8_Bilinear(AgoNode * node, AgoKernelCommand cm
             oImg->hip_memory + oImg->gpu_buffer_offset,oImg->u.img.stride_in_bytes,
             iImg->u.img.width, iImg->u.img.height,
             iImg->hip_memory + iImg->gpu_buffer_offset, iImg->u.img.stride_in_bytes,
-            (ago_perspective_matrix_t *)(iMat->hip_memory + iMat->gpu_buffer_offset))) {
+            iImg->size, (ago_perspective_matrix_t *)(iMat->hip_memory + iMat->gpu_buffer_offset))) {
             status = VX_FAILURE;
         }
     }

--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -18243,7 +18243,7 @@ int agoKernel_Remap_U8_U8_Nearest(AgoNode * node, AgoKernelCommand cmd)
             oImg->hip_memory + oImg->gpu_buffer_offset,oImg->u.img.stride_in_bytes,
             iImg->u.img.width, iImg->u.img.height,
             iImg->hip_memory + iImg->gpu_buffer_offset, iImg->u.img.stride_in_bytes,
-            (ago_coord2d_ushort_t *)iMap->hip_memory,
+            iImg->size, (ago_coord2d_ushort_t *)iMap->hip_memory,
             iMap->u.remap.dst_width * sizeof(ago_coord2d_ushort_t))) {
             status = VX_FAILURE;
         }
@@ -18336,7 +18336,7 @@ int agoKernel_Remap_U8_U8_Nearest_Constant(AgoNode * node, AgoKernelCommand cmd)
             oImg->hip_memory + oImg->gpu_buffer_offset,oImg->u.img.stride_in_bytes,
             iImg->u.img.width, iImg->u.img.height,
             iImg->hip_memory + iImg->gpu_buffer_offset, iImg->u.img.stride_in_bytes,
-            (ago_coord2d_ushort_t *)iMap->hip_memory,
+            iImg->size, (ago_coord2d_ushort_t *)iMap->hip_memory,
             iMap->u.remap.dst_width * sizeof(ago_coord2d_ushort_t),
             node->paramList[3]->u.scalar.u.u)) {
             status = VX_FAILURE;

--- a/amd_openvx/openvx/hipvx/geometric_kernels.cpp
+++ b/amd_openvx/openvx/hipvx/geometric_kernels.cpp
@@ -767,7 +767,7 @@ __global__ void __attribute__((visibility("default")))
 Hip_WarpAffine_U8_U8_Nearest(uint dstWidth, uint dstHeight,
     uchar *pDstImage, uint dstImageStrideInBytes,
     const uchar *pSrcImage, uint srcImageStrideInBytes,
-    d_affine_matrix_t *affineMatrix) {
+    uint srcImageBufferSize, d_affine_matrix_t *affineMatrix) {
 
     int x = (hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x) * 8;
     int y = hipBlockDim_y * hipBlockIdx_y + hipThreadIdx_y;
@@ -778,7 +778,7 @@ Hip_WarpAffine_U8_U8_Nearest(uint dstWidth, uint dstHeight,
 
     uint dstIdx =  y * dstImageStrideInBytes + x;
 
-    uint2 dst;
+    uint2 dst = (uint2)0;
     float sx, sy;
     float dx = (float)x;
     float dy = (float)y;
@@ -787,37 +787,52 @@ Hip_WarpAffine_U8_U8_Nearest(uint dstWidth, uint dstHeight,
     sy = fmaf(dy, affineMatrix->m[1][1], affineMatrix->m[2][1]);
     sy = fmaf(dx, affineMatrix->m[0][1], sy);
 
-    dst.x = pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx)];
+    uint srcIdx = hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx);
+    if (srcIdx < srcImageBufferSize)
+        dst.x = pSrcImage[srcIdx];
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
-    dst.x |= pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx)] << 8;
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx);
+    if (srcIdx < srcImageBufferSize)
+        dst.x |= pSrcImage[srcIdx] << 8;
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
-    dst.x |= pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx)] << 16;
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx);
+    if (srcIdx < srcImageBufferSize)
+        dst.x |= pSrcImage[srcIdx] << 16;
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
-    dst.x |= pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx)] << 24;
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx);
+    if (srcIdx < srcImageBufferSize)
+        dst.x |= pSrcImage[srcIdx] << 24;
 
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
 
-    dst.y  = pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx)];
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx);
+    if (srcIdx < srcImageBufferSize)
+        dst.y  = pSrcImage[srcIdx];
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
-    dst.y |= pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx)] << 8;
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx);
+    if (srcIdx < srcImageBufferSize)
+        dst.y |= pSrcImage[srcIdx] << 8;
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
-    dst.y |= pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx)] << 16;
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx);
+    if (srcIdx < srcImageBufferSize)
+        dst.y |= pSrcImage[srcIdx] << 16;
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
-    dst.y |= pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx)] << 24;
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)sy, (uint)sx);
+    if (srcIdx < srcImageBufferSize)
+        dst.y |= pSrcImage[srcIdx] << 24;
 
     *((uint2 *)(&pDstImage[dstIdx])) = dst;
 }
 int HipExec_WarpAffine_U8_U8_Nearest(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeight,
-    vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
-    vx_uint32 srcWidth, vx_uint32 srcHeight,
-    const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,
+    vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes, vx_uint32 srcWidth, vx_uint32 srcHeight,
+    const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes, vx_uint32 srcImageBufferSize,
     ago_affine_matrix_t *affineMatrix) {
     int localThreads_x = 16;
     int localThreads_y = 16;
@@ -826,7 +841,7 @@ int HipExec_WarpAffine_U8_U8_Nearest(hipStream_t stream, vx_uint32 dstWidth, vx_
 
     hipLaunchKernelGGL(Hip_WarpAffine_U8_U8_Nearest, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
-                        (const uchar *)pHipSrcImage, srcImageStrideInBytes,
+                        (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         (d_affine_matrix_t *) affineMatrix);
 
     return VX_SUCCESS;
@@ -979,7 +994,7 @@ __global__ void __attribute__((visibility("default")))
 Hip_WarpAffine_U8_U8_Bilinear(uint dstWidth, uint dstHeight,
     uchar *pDstImage, uint dstImageStrideInBytes,
     const uchar *pSrcImage, uint srcImageStrideInBytes,
-    d_affine_matrix_t *affineMatrix) {
+    uint srcImageBufferSize, d_affine_matrix_t *affineMatrix) {
 
     int x = (hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x) * 8;
     int y = hipBlockDim_y * hipBlockIdx_y + hipThreadIdx_y;
@@ -1000,31 +1015,31 @@ Hip_WarpAffine_U8_U8_Bilinear(uint dstWidth, uint dstHeight,
     sy = fmaf(dy, affineMatrix->m[1][1], affineMatrix->m[2][1]);
     sy = fmaf(dx, affineMatrix->m[0][1], sy);
 
-    f.x = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx, sy);
+    f.x = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx, sy);
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
-    f.y = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx, sy);
+    f.y = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx, sy);
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
-    f.z = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx, sy);
+    f.z = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx, sy);
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
-    f.w = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx, sy);
+    f.w = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx, sy);
     dst.x = hip_pack(f);
 
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
 
-    f.x = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx, sy);
+    f.x = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx, sy);
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
-    f.y = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx, sy);
+    f.y = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx, sy);
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
-    f.z = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx, sy);
+    f.z = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx, sy);
     sx += affineMatrix->m[0][0];
     sy += affineMatrix->m[0][1];
-    f.w = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx, sy);
+    f.w = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx, sy);
     dst.y = hip_pack(f);
 
     *((uint2 *)(&pDstImage[dstIdx])) = dst;
@@ -1033,7 +1048,7 @@ int HipExec_WarpAffine_U8_U8_Bilinear(hipStream_t stream, vx_uint32 dstWidth, vx
     vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
     vx_uint32 srcWidth, vx_uint32 srcHeight,
     const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,
-    ago_affine_matrix_t *affineMatrix) {
+    vx_uint32 srcImageBufferSize, ago_affine_matrix_t *affineMatrix) {
     int localThreads_x = 16;
     int localThreads_y = 16;
     int globalThreads_x = (dstWidth + 7) >> 3;
@@ -1041,7 +1056,7 @@ int HipExec_WarpAffine_U8_U8_Bilinear(hipStream_t stream, vx_uint32 dstWidth, vx
 
     hipLaunchKernelGGL(Hip_WarpAffine_U8_U8_Bilinear, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
-                        (const uchar *)pHipSrcImage, srcImageStrideInBytes,
+                        (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         (d_affine_matrix_t *) affineMatrix);
 
     return VX_SUCCESS;
@@ -1127,7 +1142,7 @@ __global__ void __attribute__((visibility("default")))
 Hip_WarpPerspective_U8_U8_Nearest(uint dstWidth, uint dstHeight,
     uchar *pDstImage, uint dstImageStrideInBytes,
     const uchar *pSrcImage, uint srcImageStrideInBytes,
-    d_perspective_matrix_t *perspectiveMatrix) {
+    uint srcImageBufferSize, d_perspective_matrix_t *perspectiveMatrix) {
 
     int x = (hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x) * 8;
     int y = hipBlockDim_y * hipBlockIdx_y + hipThreadIdx_y;
@@ -1138,7 +1153,7 @@ Hip_WarpPerspective_U8_U8_Nearest(uint dstWidth, uint dstHeight,
 
     uint dstIdx =  y * dstImageStrideInBytes + x;
 
-    uint2 dst;
+    uint2 dst = (uint2)0;
     float sx, sy, sz, isz;
     float dx = (float)x;
     float dy = (float)y;
@@ -1151,49 +1166,65 @@ Hip_WarpPerspective_U8_U8_Nearest(uint dstWidth, uint dstHeight,
 
     isz = 1.0f / sz;
 
-    dst.x = pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz))];
+    uint srcIdx = hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz));
+    if (srcIdx < srcImageBufferSize)
+        dst.x = pSrcImage[srcIdx];
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    dst.x |= pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz))] << 8;
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz));
+    if (srcIdx < srcImageBufferSize)
+        dst.x |= pSrcImage[srcIdx] << 8;
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    dst.x |= pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz))] << 16;
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz));
+    if (srcIdx < srcImageBufferSize)
+        dst.x |= pSrcImage[srcIdx] << 16;
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    dst.x |= pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz))] << 24;
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz));
+    if (srcIdx < srcImageBufferSize)
+        dst.x |= pSrcImage[srcIdx] << 24;
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    dst.y  = pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz))];
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz));
+    if (srcIdx < srcImageBufferSize)
+        dst.y  = pSrcImage[srcIdx];
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    dst.y |= pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz))] << 8;
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz));
+    if (srcIdx < srcImageBufferSize)
+        dst.y |= pSrcImage[srcIdx] << 8;
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    dst.y |= pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz))] << 16;
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz));
+    if (srcIdx < srcImageBufferSize)
+        dst.y |= pSrcImage[srcIdx] << 16;
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    dst.y |= pSrcImage[hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz))] << 24;
+    srcIdx = hip_mad24(srcImageStrideInBytes, (uint)(sy * isz), (uint)(sx * isz));
+    if (srcIdx < srcImageBufferSize)
+        dst.y |= pSrcImage[srcIdx] << 24;
 
     *((uint2 *)(&pDstImage[dstIdx])) = dst;
 }
 int HipExec_WarpPerspective_U8_U8_Nearest(hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeight,
     vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
     vx_uint32 srcWidth, vx_uint32 srcHeight,
-    const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,
+    const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes, vx_uint32 srcImageBufferSize,
     ago_perspective_matrix_t *perspectiveMatrix) {
     int localThreads_x = 16;
     int localThreads_y = 16;
@@ -1202,7 +1233,7 @@ int HipExec_WarpPerspective_U8_U8_Nearest(hipStream_t stream, vx_uint32 dstWidth
 
     hipLaunchKernelGGL(Hip_WarpPerspective_U8_U8_Nearest, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
-                        (const uchar *)pHipSrcImage, srcImageStrideInBytes,
+                        (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         (d_perspective_matrix_t *) perspectiveMatrix);
 
     return VX_SUCCESS;
@@ -1373,7 +1404,7 @@ __global__ void __attribute__((visibility("default")))
 Hip_WarpPerspective_U8_U8_Bilinear(uint dstWidth, uint dstHeight,
     uchar *pDstImage, uint dstImageStrideInBytes,
     const uchar *pSrcImage, uint srcImageStrideInBytes,
-    d_perspective_matrix_t *perspectiveMatrix) {
+    uint srcImageBufferSize, d_perspective_matrix_t *perspectiveMatrix) {
 
     int x = (hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x) * 8;
     int y = hipBlockDim_y * hipBlockIdx_y + hipThreadIdx_y;
@@ -1398,22 +1429,22 @@ Hip_WarpPerspective_U8_U8_Bilinear(uint dstWidth, uint dstHeight,
 
     isz = 1.0f / sz;
 
-    f.x = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx * isz, sy * isz);
+    f.x = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx * isz, sy * isz);
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    f.y = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx * isz, sy * isz);
+    f.y = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx * isz, sy * isz);
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    f.z = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx * isz, sy * isz);
+    f.z = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx * isz, sy * isz);
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    f.w = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx * isz, sy * isz);
+    f.w = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx * isz, sy * isz);
     dst.x = hip_pack(f);
 
     sx += perspectiveMatrix->m[0][0];
@@ -1421,22 +1452,22 @@ Hip_WarpPerspective_U8_U8_Bilinear(uint dstWidth, uint dstHeight,
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
 
-    f.x = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx * isz, sy * isz);
+    f.x = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx * isz, sy * isz);
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    f.y = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx * isz, sy * isz);
+    f.y = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx * isz, sy * isz);
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    f.z = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx * isz, sy * isz);
+    f.z = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx * isz, sy * isz);
     sx += perspectiveMatrix->m[0][0];
     sy += perspectiveMatrix->m[0][1];
     sz += perspectiveMatrix->m[0][2];
     isz = 1.0f / sz;
-    f.w = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, sx * isz, sy * isz);
+    f.w = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, sx * isz, sy * isz);
     dst.y = hip_pack(f);
 
     *((uint2 *)(&pDstImage[dstIdx])) = dst;
@@ -1445,7 +1476,7 @@ int HipExec_WarpPerspective_U8_U8_Bilinear(hipStream_t stream, vx_uint32 dstWidt
     vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
     vx_uint32 srcWidth, vx_uint32 srcHeight,
     const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,
-    ago_perspective_matrix_t *perspectiveMatrix) {
+    vx_uint32 srcImageBufferSize, ago_perspective_matrix_t *perspectiveMatrix) {
     int localThreads_x = 16;
     int localThreads_y = 16;
     int globalThreads_x = (dstWidth + 7) >> 3;
@@ -1453,7 +1484,7 @@ int HipExec_WarpPerspective_U8_U8_Bilinear(hipStream_t stream, vx_uint32 dstWidt
 
     hipLaunchKernelGGL(Hip_WarpPerspective_U8_U8_Bilinear, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage , dstImageStrideInBytes,
-                        (const uchar *)pHipSrcImage, srcImageStrideInBytes,
+                        (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         (d_perspective_matrix_t *) perspectiveMatrix);
 
     return VX_SUCCESS;
@@ -1775,7 +1806,7 @@ __global__ void __attribute__((visibility("default")))
 Hip_Remap_U8_U8_Bilinear(uint dstWidth, uint dstHeight,
     uchar *pDstImage, uint dstImageStrideInBytes,
     const uchar *pSrcImage, uint srcImageStrideInBytes,
-    uchar *remap_, uint remapStrideInBytes) {
+    uint srcImageBufferSize, uchar *remap_, uint remapStrideInBytes) {
 
     int x = (hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x) * 8;
     int y = hipBlockDim_y * hipBlockIdx_y + hipThreadIdx_y;
@@ -1792,23 +1823,23 @@ Hip_Remap_U8_U8_Bilinear(uint dstWidth, uint dstHeight,
     int map;
 
     map = remap[0];
-    f.x = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
+    f.x = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
     map = remap[1];
-    f.y = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
+    f.y = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
     map = remap[2];
-    f.z = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
+    f.z = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
     map = remap[3];
-    f.w = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
+    f.w = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
     dst.x = hip_pack(f);
 
     map = remap[4];
-    f.x = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
+    f.x = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
     map = remap[5];
-    f.y = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
+    f.y = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
     map = remap[6];
-    f.z = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
+    f.z = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
     map = remap[7];
-    f.w = hip_bilinear_sample_FXY(pSrcImage, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
+    f.w = hip_bilinear_sample_FXY(pSrcImage, srcImageBufferSize, srcImageStrideInBytes, ((map << 16) >> 16) * 0.125f, (map >> 16) * 0.125f);
     dst.y = hip_pack(f);
 
     *((uint2 *)(&pDstImage[dstIdx])) = dst;
@@ -1817,7 +1848,7 @@ int HipExec_Remap_U8_U8_Bilinear(hipStream_t stream, vx_uint32 dstWidth, vx_uint
     vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
     vx_uint32 srcWidth, vx_uint32 srcHeight,
     const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,
-    ago_coord2d_ushort_t *remap, vx_uint32 remapStrideInBytes) {
+    vx_uint32 srcImageBufferSize, ago_coord2d_ushort_t *remap, vx_uint32 remapStrideInBytes) {
     int localThreads_x = 16;
     int localThreads_y = 16;
     int globalThreads_x = (dstWidth + 7) >> 3;
@@ -1825,7 +1856,7 @@ int HipExec_Remap_U8_U8_Bilinear(hipStream_t stream, vx_uint32 dstWidth, vx_uint
 
     hipLaunchKernelGGL(Hip_Remap_U8_U8_Bilinear, dim3(ceil((float)globalThreads_x/localThreads_x), ceil((float)globalThreads_y/localThreads_y)),
                         dim3(localThreads_x, localThreads_y), 0, stream, dstWidth, dstHeight, (uchar *)pHipDstImage, dstImageStrideInBytes,
-                        (const uchar *)pHipSrcImage, srcImageStrideInBytes,
+                        (const uchar *)pHipSrcImage, srcImageStrideInBytes, srcImageBufferSize,
                         (uchar *) remap, remapStrideInBytes);
 
     return VX_SUCCESS;

--- a/amd_openvx/openvx/hipvx/hip_common_funcs.h
+++ b/amd_openvx/openvx/hipvx/hip_common_funcs.h
@@ -218,7 +218,7 @@ __device__ __forceinline__ float hip_bilinear_sample(const uchar *p, uint ystrid
     return f.x;
 }
 
-__device__ __forceinline__ float hip_bilinear_sample_FXY(const uchar *p, uint stride, float sx, float sy) {
+__device__ __forceinline__ float hip_bilinear_sample_FXY(const uchar *p, uint pSize, uint stride, float sx, float sy) {
     float fx0, fx1, fy0, fy1, ii;
     uint x, y;
     fx1 = hip_fract(sx, &ii);
@@ -227,7 +227,9 @@ __device__ __forceinline__ float hip_bilinear_sample_FXY(const uchar *p, uint st
     fy1 = hip_fract(sy, &ii);
     fy0 = 1.0f - fy1;
     y = (uint)ii;
-    p += hip_mad24(stride, y, x);
+    uint srcIdx = hip_mad24(stride, y, x);
+    if (srcIdx < pSize)
+        p += srcIdx;
     return hip_bilinear_sample(p, stride, 1, fy0, fy1, 0, fx0, fx1);
 }
 

--- a/amd_openvx/openvx/hipvx/hip_host_decls.h
+++ b/amd_openvx/openvx/hipvx/hip_host_decls.h
@@ -802,13 +802,13 @@ int HipExec_Remap_U8_U8_Nearest(
         hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeight,
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
         vx_uint32 srcWidth, vx_uint32 srcHeight,
-        const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,
+        const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes, vx_uint32 srcImageBufferSize,
         ago_coord2d_ushort_t *remap, vx_uint32 remapStrideInBytes);
 int HipExec_Remap_U8_U8_Nearest_Constant(
         hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeight,
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
         vx_uint32 srcWidth, vx_uint32 srcHeight,
-        const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,
+        const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,vx_uint32 srcImageBufferSize,
         ago_coord2d_ushort_t *remap, vx_uint32 remapStrideInBytes, const vx_uint8 borderValue);
 int HipExec_Remap_U8_U8_Bilinear(
         hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeight,

--- a/amd_openvx/openvx/hipvx/hip_host_decls.h
+++ b/amd_openvx/openvx/hipvx/hip_host_decls.h
@@ -751,7 +751,7 @@ int HipExec_WarpAffine_U8_U8_Nearest(
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
         vx_uint32 srcWidth, vx_uint32 srcHeight,
         const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,
-        ago_affine_matrix_t *affineMatrix);
+        vx_uint32 srcImageBufferSize, ago_affine_matrix_t *affineMatrix);
 int HipExec_WarpAffine_U8_U8_Nearest_Constant(
         hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeight,
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
@@ -764,7 +764,7 @@ int HipExec_WarpAffine_U8_U8_Bilinear(
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
         vx_uint32 srcWidth, vx_uint32 srcHeight,
         const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,
-        ago_affine_matrix_t *affineMatrix);
+        vx_uint32 srcImageBufferSize, ago_affine_matrix_t *affineMatrix);
 int HipExec_WarpAffine_U8_U8_Bilinear_Constant(
         hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeight,
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
@@ -777,7 +777,7 @@ int HipExec_WarpPerspective_U8_U8_Nearest(
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
         vx_uint32 srcWidth, vx_uint32 srcHeight,
         const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,
-        ago_perspective_matrix_t *perspectiveMatrix);
+        vx_uint32 srcImageBufferSize, ago_perspective_matrix_t *perspectiveMatrix);
 int HipExec_WarpPerspective_U8_U8_Nearest_Constant(
         hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeight,
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
@@ -790,7 +790,7 @@ int HipExec_WarpPerspective_U8_U8_Bilinear(
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
         vx_uint32 srcWidth, vx_uint32 srcHeight,
         const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,
-        ago_perspective_matrix_t *perspectiveMatrix);
+        vx_uint32 srcImageBufferSize, ago_perspective_matrix_t *perspectiveMatrix);
 int HipExec_WarpPerspective_U8_U8_Bilinear_Constant(
         hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeight,
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
@@ -815,7 +815,7 @@ int HipExec_Remap_U8_U8_Bilinear(
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,
         vx_uint32 srcWidth, vx_uint32 srcHeight,
         const vx_uint8 *pHipSrcImage, vx_uint32 srcImageStrideInBytes,
-        ago_coord2d_ushort_t *remap, vx_uint32 remapStrideInBytes);
+        vx_uint32 srcImageBufferSize, ago_coord2d_ushort_t *remap, vx_uint32 remapStrideInBytes);
 int HipExec_Remap_U8_U8_Bilinear_Constant(
         hipStream_t stream, vx_uint32 dstWidth, vx_uint32 dstHeight,
         vx_uint8 *pHipDstImage, vx_uint32 dstImageStrideInBytes,


### PR DESCRIPTION
- This PR fixes the failures reported in issue #566 for the HIP backend for WarpPerspective kernels where out-of-bound access caused a segfault.



