### PR TITLE
Fix Windows build

### DIFF
--- a/amd_openvx/openvx/ago/ago_platform.cpp
+++ b/amd_openvx/openvx/ago/ago_platform.cpp
@@ -97,7 +97,7 @@ bool agoSetEnvironmentVariable(const char * name, const char * value)
 bool agoUnsetEnvironmentVariable(const char * name)
 {
 #if _WIN32
-    return SetEnvironmentVariableA(name, null);
+    return SetEnvironmentVariableA(name, NULL);
 #else
     return !(unsetenv(name));
 #endif

--- a/amd_openvx/openvx/openvx.vcxproj
+++ b/amd_openvx/openvx/openvx.vcxproj
@@ -105,6 +105,7 @@
     <ClCompile Include="ago\ago_haf_cpu_fast_corners.cpp" />
     <ClCompile Include="ago\ago_haf_cpu_filter.cpp" />
     <ClCompile Include="ago\ago_haf_cpu_geometric.cpp" />
+	<ClCompile Include="ago\ago_haf_cpu_generic_functions.cpp" />
     <ClCompile Include="ago\ago_haf_cpu_harris.cpp" />
     <ClCompile Include="ago\ago_haf_cpu_histogram.cpp" />
     <ClCompile Include="ago\ago_haf_cpu_logical.cpp" />

--- a/amd_openvx/openvx/openvx.vcxproj.filters
+++ b/amd_openvx/openvx/openvx.vcxproj.filters
@@ -122,6 +122,9 @@
     <ClCompile Include="ago\ago_platform.cpp">
       <Filter>Source Files\ago</Filter>
     </ClCompile>
+    <ClCompile Include="ago\ago_haf_cpu_generic_functions.cpp">
+      <Filter>Source Files\ago</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="include\VX\vx.h">


### PR DESCRIPTION
Fix minor issues preventing build on Windows
- use `NULL` instead of undefined `null`
- include `ago\ago_haf_cpu_generic_functions.cpp` in .vcxproj file to compile it