### PR TITLE
MIVisionX Package -  Set dependency on rocm-core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,6 @@ if(ROCM_DEP_ROCMCORE )
   set(CPACK_RPM_PACKAGE_REQUIRES   "rocm-core")
 endif()
 
-
 # '%{?dist}' breaks manual builds on debian systems due to empty Provides
 execute_process(COMMAND rpm --eval %{?dist}
                 RESULT_VARIABLE PROC_RESULT

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,10 +147,9 @@ if(DEFINED ENV{CPACK_RPM_PACKAGE_RELEASE})
   set(CPACK_RPM_PACKAGE_RELEASE $ENV{CPACK_RPM_PACKAGE_RELEASE})
 endif()
 
-#Set dependency to ROCm if set to TRUE, default to OFF
-set (ROCM_DEP_ROCMCORE OFF CACHE BOOL "Set rocm-core dependency")
-
-if(ROCM_DEP_ROCMCORE )
+# set dependency to ROCm if set to TRUE, default to OFF
+set(ROCM_DEP_ROCMCORE OFF CACHE BOOL "Set rocm-core dependency")
+if(ROCM_DEP_ROCMCORE)
   set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-core")
   set(CPACK_RPM_PACKAGE_REQUIRES   "rocm-core")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,15 @@ if(DEFINED ENV{CPACK_RPM_PACKAGE_RELEASE})
   set(CPACK_RPM_PACKAGE_RELEASE $ENV{CPACK_RPM_PACKAGE_RELEASE})
 endif()
 
+#Set dependency to ROCm if set to TRUE, default to OFF
+set (ROCM_DEP_ROCMCORE OFF CACHE BOOL "Set rocm-core dependency")
+
+if(ROCM_DEP_ROCMCORE )
+  set(CPACK_DEBIAN_PACKAGE_DEPENDS "rocm-core")
+  set(CPACK_RPM_PACKAGE_REQUIRES   "rocm-core")
+endif()
+
+
 # '%{?dist}' breaks manual builds on debian systems due to empty Provides
 execute_process(COMMAND rpm --eval %{?dist}
                 RESULT_VARIABLE PROC_RESULT


### PR DESCRIPTION
This will set dependency to rocm-core package if ROCM_DEP_ROCMCORE
flag is set to ON.