### PR TITLE
OpenVX - rename VX_KERNEL_ATTRIBUTE_AMD_OPENCL_BUFFER_UPDATE_CALLBACK to … to VX_KERNEL_ATTRIBUTE_AMD_GPU_BUFFER_UPDATE_CALLBACK

### DIFF
--- a/amd_openvx/openvx/ago/ago_interface.cpp
+++ b/amd_openvx/openvx/ago/ago_interface.cpp
@@ -1249,13 +1249,13 @@ vx_status agoVerifyNode(AgoNode * node)
         }
     }
 
-    // mark the kernels with VX_KERNEL_ATTRIBUTE_AMD_OPENCL_BUFFER_UPDATE_CALLBACK
+    // mark the kernels with VX_KERNEL_ATTRIBUTE_AMD_GPU_BUFFER_UPDATE_CALLBACK
     // with enableUserBufferGPU
     if (kernel->gpu_buffer_update_callback_f) {
-        AgoData * data = node->paramList[kernel->opencl_buffer_update_param_index];
+        AgoData * data = node->paramList[kernel->gpu_buffer_update_param_index];
         if (!data || !data->isVirtual || data->ref.type != VX_TYPE_IMAGE || data->u.img.planes != 1 || data->ownerOfUserBufferGPU || data->u.img.enableUserBufferGPU) {
             status = VX_ERROR_INVALID_PARAMETERS;
-            agoAddLogEntry(&kernel->ref, status, "ERROR: agoVerifyGraph: kernel %s: unexpected/unsupported argument#%d -- needs virtual image with single-plane\n", kernel->name, kernel->opencl_buffer_update_param_index);
+            agoAddLogEntry(&kernel->ref, status, "ERROR: agoVerifyGraph: kernel %s: unexpected/unsupported argument#%d -- needs virtual image with single-plane\n", kernel->name, kernel->gpu_buffer_update_param_index);
             return status;
         }
         // mark that the buffer gets initialized a node

--- a/amd_openvx/openvx/ago/ago_internal.h
+++ b/amd_openvx/openvx/ago/ago_internal.h
@@ -531,8 +531,8 @@ struct AgoKernel {
     amd_kernel_opencl_codegen_callback_f opencl_codegen_callback_f;
     amd_kernel_node_regen_callback_f regen_callback_f;
     amd_kernel_opencl_global_work_update_callback_f opencl_global_work_update_callback_f;
-    amd_kernel_opencl_buffer_update_callback_f gpu_buffer_update_callback_f;
-    vx_uint32 opencl_buffer_update_param_index;
+    amd_kernel_gpu_buffer_update_callback_f gpu_buffer_update_callback_f;
+    vx_uint32 gpu_buffer_update_param_index;
     vx_bool opencl_buffer_access_enable;
     vx_uint32 importing_module_index_plus1;
 public:

--- a/amd_openvx/openvx/ago/ago_util.cpp
+++ b/amd_openvx/openvx/ago/ago_util.cpp
@@ -3198,7 +3198,7 @@ AgoKernel::AgoKernel()
       localDataSize{ 0 }, localDataPtr{ nullptr }, external_kernel{ false }, finalized{ false },
       kernel_f{ nullptr }, validate_f{ nullptr }, input_validate_f{ nullptr }, output_validate_f{ nullptr }, initialize_f{ nullptr }, deinitialize_f{ nullptr },
       query_target_support_f{ nullptr }, opencl_codegen_callback_f{ nullptr }, regen_callback_f{ nullptr }, opencl_global_work_update_callback_f{ nullptr },
-      gpu_buffer_update_callback_f{ nullptr }, opencl_buffer_update_param_index{ 0 },
+      gpu_buffer_update_callback_f{ nullptr }, gpu_buffer_update_param_index{ 0 },
       opencl_buffer_access_enable{ vx_false_e }, importing_module_index_plus1{ 0 }
 {
     memset(&name, 0, sizeof(name));

--- a/amd_openvx/openvx/api/vx_api.cpp
+++ b/amd_openvx/openvx/api/vx_api.cpp
@@ -2812,22 +2812,22 @@ VX_API_ENTRY vx_status VX_API_CALL vxSetKernelAttribute(vx_kernel kernel, vx_enu
                     }
                 }
                 break;
-            case VX_KERNEL_ATTRIBUTE_AMD_OPENCL_BUFFER_UPDATE_CALLBACK:
-                if (size == sizeof(AgoKernelOpenclBufferUpdateInfo)) {
+            case VX_KERNEL_ATTRIBUTE_AMD_GPU_BUFFER_UPDATE_CALLBACK:
+                if (size == sizeof(AgoKernelGpuBufferUpdateInfo)) {
                     if (!kernel->finalized) {
-                        AgoKernelOpenclBufferUpdateInfo * info = (AgoKernelOpenclBufferUpdateInfo *)ptr;
-                        if (info->opencl_buffer_update_param_index >= kernel->argCount ||
+                        AgoKernelGpuBufferUpdateInfo * info = (AgoKernelGpuBufferUpdateInfo *)ptr;
+                        if (info->gpu_buffer_update_param_index >= kernel->argCount ||
                             info->gpu_buffer_update_callback_f == nullptr ||
-                            kernel->parameters[info->opencl_buffer_update_param_index].direction != VX_INPUT ||
-                            kernel->parameters[info->opencl_buffer_update_param_index].type != VX_TYPE_IMAGE ||
-                            kernel->parameters[info->opencl_buffer_update_param_index].state != VX_PARAMETER_STATE_REQUIRED)
+                            kernel->parameters[info->gpu_buffer_update_param_index].direction != VX_INPUT ||
+                            kernel->parameters[info->gpu_buffer_update_param_index].type != VX_TYPE_IMAGE ||
+                            kernel->parameters[info->gpu_buffer_update_param_index].state != VX_PARAMETER_STATE_REQUIRED)
                         {
                             // param index has to point to required input images only
                             status = VX_ERROR_INVALID_PARAMETERS;
                         }
                         else {
                             kernel->gpu_buffer_update_callback_f = info->gpu_buffer_update_callback_f;
-                            kernel->opencl_buffer_update_param_index = info->opencl_buffer_update_param_index;
+                            kernel->gpu_buffer_update_param_index = info->gpu_buffer_update_param_index;
                             kernel->opencl_buffer_access_enable = vx_true_e;
                             status = VX_SUCCESS;
                         }

--- a/amd_openvx/openvx/include/vx_ext_amd.h
+++ b/amd_openvx/openvx/include/vx_ext_amd.h
@@ -124,8 +124,8 @@ enum vx_kernel_attribute_amd_e {
     VX_KERNEL_ATTRIBUTE_AMD_OPENCL_GLOBAL_WORK_UPDATE_CALLBACK = VX_ATTRIBUTE_BASE(VX_ID_AMD, VX_TYPE_KERNEL) + 0x04,
     /*! \brief kernel flag to enable OpenCL buffer access (default OFF). Use a <tt>\ref vx_bool</tt> parameter.*/
     VX_KERNEL_ATTRIBUTE_AMD_GPU_BUFFER_ACCESS_ENABLE        = VX_ATTRIBUTE_BASE(VX_ID_AMD, VX_TYPE_KERNEL) + 0x05,
-    /*! \brief kernel callback for OpenCL buffer update. Use a <tt>\ref AgoKernelOpenclBufferUpdateInfo</tt> parameter.*/
-    VX_KERNEL_ATTRIBUTE_AMD_OPENCL_BUFFER_UPDATE_CALLBACK      = VX_ATTRIBUTE_BASE(VX_ID_AMD, VX_TYPE_KERNEL) + 0x06,
+    /*! \brief kernel callback for GPU buffer update. Use a <tt>\ref AgoKernelGpuBufferUpdateInfo</tt> parameter.*/
+    VX_KERNEL_ATTRIBUTE_AMD_GPU_BUFFER_UPDATE_CALLBACK      = VX_ATTRIBUTE_BASE(VX_ID_AMD, VX_TYPE_KERNEL) + 0x06,
 };
 
 /*! \brief The AMD graph attributes list.
@@ -387,22 +387,22 @@ typedef vx_status(VX_CALLBACK * amd_kernel_opencl_global_work_update_callback_f)
     const vx_size opencl_local_work[]              // [input] local_work[] for clEnqueueNDRangeKernel()
     );
 
-/*! \brief AMD usernode callback for setting the OpenCL buffers. The framework will pass
-*   OpenVX objects as parameters to OpenCL kernels in othe order they appear to OpenVX node.
+/*! \brief AMD usernode callback for setting the GPU buffers. The framework will pass
+*   OpenVX objects as parameters to GPU kernels in othe order they appear to OpenVX node.
 *   This function will get called before executing the node.
 */
-typedef vx_status(VX_CALLBACK * amd_kernel_opencl_buffer_update_callback_f) (
+typedef vx_status(VX_CALLBACK * amd_kernel_gpu_buffer_update_callback_f) (
     vx_node node,                                  // [input] node
     const vx_reference parameters[],               // [input] parameters
     vx_uint32 num                                  // [input] number of parameters
     );
 
-/*! \brief AMD data structure for use by VX_KERNEL_ATTRIBUTE_AMD_OPENCL_BUFFER_UPDATE_CALLBACK.
+/*! \brief AMD data structure for use by VX_KERNEL_ATTRIBUTE_AMD_GPU_BUFFER_UPDATE_CALLBACK.
 */
 typedef struct {
-    amd_kernel_opencl_buffer_update_callback_f gpu_buffer_update_callback_f;
-    vx_uint32 opencl_buffer_update_param_index;
-} AgoKernelOpenclBufferUpdateInfo;
+    amd_kernel_gpu_buffer_update_callback_f gpu_buffer_update_callback_f;
+    vx_uint32 gpu_buffer_update_param_index;
+} AgoKernelGpuBufferUpdateInfo;
 #endif
 
 #ifdef  __cplusplus

--- a/amd_openvx_extensions/amd_media/encoder.cpp
+++ b/amd_openvx_extensions/amd_media/encoder.cpp
@@ -506,7 +506,7 @@ void CLoomIoMediaEncoder::EncodeLoop()
 
 #if ENCODE_ENABLE_OPENCL
 //! \brief The kernel execution.
-static vx_status VX_CALLBACK amd_media_encode_opencl_buffer_update_callback(vx_node node, const vx_reference parameters[], vx_uint32 num)
+static vx_status VX_CALLBACK amd_media_encode_gpu_buffer_update_callback(vx_node node, const vx_reference parameters[], vx_uint32 num)
 {
     // get encoder and input image
     CLoomIoMediaEncoder * encoder = nullptr;
@@ -623,9 +623,9 @@ vx_status amd_media_encode_publish(vx_context context)
     ERROR_CHECK_STATUS(vxAddParameterToKernel(kernel, 3, VX_OUTPUT, VX_TYPE_ARRAY, VX_PARAMETER_STATE_REQUIRED));  // output auxiliary data
 
 #if ENCODE_ENABLE_OPENCL
-    // register amd_kernel_opencl_buffer_update_callback_f for input image
-    AgoKernelOpenclBufferUpdateInfo info = { amd_media_encode_opencl_buffer_update_callback, 1 };
-    ERROR_CHECK_STATUS(vxSetKernelAttribute(kernel, VX_KERNEL_ATTRIBUTE_AMD_OPENCL_BUFFER_UPDATE_CALLBACK, &info, sizeof(info)));
+    // register amd_kernel_gpu_buffer_update_callback_f for input image
+    AgoKernelGpuBufferUpdateInfo info = { amd_media_encode_gpu_buffer_update_callback, 1 };
+    ERROR_CHECK_STATUS(vxSetKernelAttribute(kernel, VX_KERNEL_ATTRIBUTE_AMD_GPU_BUFFER_UPDATE_CALLBACK, &info, sizeof(info)));
 #endif
 
     // finalize and release kernel object

--- a/utilities/loom_io_media/encoder.cpp
+++ b/utilities/loom_io_media/encoder.cpp
@@ -622,9 +622,9 @@ vx_status loomio_media_encode_publish(vx_context context)
     ERROR_CHECK_STATUS(vxAddParameterToKernel(kernel, 3, VX_OUTPUT, VX_TYPE_ARRAY, VX_PARAMETER_STATE_REQUIRED));  // output auxiliary data
 
 #if ENCODE_ENABLE_OPENCL
-    // register amd_kernel_opencl_buffer_update_callback_f for input image
-    AgoKernelOpenclBufferUpdateInfo info = { loomio_media_encode_opencl_buffer_update_callback, 1 };
-    ERROR_CHECK_STATUS(vxSetKernelAttribute(kernel, VX_KERNEL_ATTRIBUTE_AMD_OPENCL_BUFFER_UPDATE_CALLBACK, &info, sizeof(info)));
+    // register amd_kernel_gpu_buffer_update_callback_f for input image
+    AgoKernelGpuBufferUpdateInfo info = { loomio_media_encode_opencl_buffer_update_callback, 1 };
+    ERROR_CHECK_STATUS(vxSetKernelAttribute(kernel, VX_KERNEL_ATTRIBUTE_AMD_GPU_BUFFER_UPDATE_CALLBACK, &info, sizeof(info)));
 #endif
 
     // finalize and release kernel object


### PR DESCRIPTION
this PR also renames the following variables as they are used with both OCL/HIP GPU backends.

amd_kernel_opencl_buffer_update_callback_f to amd_kernel_gpu_buffer_update_callback_f
opencl_buffer_update_param_index to gpu_buffer_update_param_index
AgoKernelOpenclBufferUpdateInfo to AgoKernelGpuBufferUpdateInfo