### PR TITLE
OpenVX OCL GPU backend - Fix syncing issue

### DIFF
--- a/amd_openvx/openvx/ago/ago_util_opencl.cpp
+++ b/amd_openvx/openvx/ago/ago_util_opencl.cpp
@@ -383,11 +383,15 @@ int agoGpuOclAllocBuffer(AgoData * data)
             }
             else {
                 vx_uint32 zero = 0;
-                err = clEnqueueFillBuffer(context->opencl_cmdq, dataMaster->opencl_buffer, &zero, sizeof(zero), 0, dataMaster->gpu_buffer_offset + dataMaster->size, 0, NULL, NULL);
+                cl_event event;
+                err = clEnqueueFillBuffer(context->opencl_cmdq, dataMaster->opencl_buffer, &zero, sizeof(zero), 0, dataMaster->gpu_buffer_offset + dataMaster->size, 0, NULL, &event);
                 if (err) {
                     agoAddLogEntry(&context->ref, VX_FAILURE, "ERROR: clEnqueueFillBuffer() => %d\n", err);
                     return -1;
                 }
+                clWaitForEvents(1, &event);
+                
+
             }
             if (dataMaster->u.img.isUniform) {
                 // make sure that CPU buffer is allocated
@@ -402,6 +406,7 @@ int agoGpuOclAllocBuffer(AgoData * data)
                     agoAddLogEntry(&context->ref, VX_FAILURE, "ERROR: agoGpuOclAllocBuffer: clEnqueueWriteBuffer() => %d\n", err);
                     return -1; 
                 }
+                
                 dataMaster->buffer_sync_flags |= AGO_BUFFER_SYNC_FLAG_DIRTY_SYNCHED;
             }
         }

--- a/amd_openvx/openvx/ago/ago_util_opencl.cpp
+++ b/amd_openvx/openvx/ago/ago_util_opencl.cpp
@@ -389,9 +389,8 @@ int agoGpuOclAllocBuffer(AgoData * data)
                     agoAddLogEntry(&context->ref, VX_FAILURE, "ERROR: clEnqueueFillBuffer() => %d\n", err);
                     return -1;
                 }
+                // make sure clEnqueueFillBuffer() is done before executing another node
                 clWaitForEvents(1, &event);
-                
-
             }
             if (dataMaster->u.img.isUniform) {
                 // make sure that CPU buffer is allocated
@@ -406,7 +405,6 @@ int agoGpuOclAllocBuffer(AgoData * data)
                     agoAddLogEntry(&context->ref, VX_FAILURE, "ERROR: agoGpuOclAllocBuffer: clEnqueueWriteBuffer() => %d\n", err);
                     return -1; 
                 }
-                
                 dataMaster->buffer_sync_flags |= AGO_BUFFER_SYNC_FLAG_DIRTY_SYNCHED;
             }
         }


### PR DESCRIPTION
Added a clWaitForEvents to make sure clEnqueueFillBuffer() is done before executing any other nodes.
This fixes the laplacian pyramid cts failure on Windows.