### PR TITLE
VX_NN - vxUpsampleNearestLayer node implementation on HIP backend

### DIFF
--- a/amd_openvx_extensions/amd_nn/nn_hip/nn_hip_host_decls.h
+++ b/amd_openvx_extensions/amd_nn/nn_hip/nn_hip_host_decls.h
@@ -3,7 +3,8 @@ Copyright (c) 2015 - 2022 Advanced Micro Devices, Inc. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+to use, copy, modify, merge, publi
+sh, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 
@@ -70,4 +71,7 @@ int HipExec_tensor_compare_layer(hipStream_t stream, dim3 globalThreads, dim3 lo
     uint in_offset, uint4 in_stride, unsigned char* in2, uint in2_offset, uint4 in2_stride, unsigned char* out, uint out_offset,
     uint4 out_stride, uint mode);
 
+int HipExec_Upsample_Nearest_layer(hipStream_t stream, dim3 globalThreads, dim3 localThreads, vx_enum type, unsigned char* in, uint in_offset,
+    uint4 in_stride, unsigned char* out, uint out_offset, uint4 out_stride);
+    
 #endif //NN_HIP_HOST_DECLS_H

--- a/amd_openvx_extensions/amd_nn/nn_hip/nn_hip_host_decls.h
+++ b/amd_openvx_extensions/amd_nn/nn_hip/nn_hip_host_decls.h
@@ -3,8 +3,7 @@ Copyright (c) 2015 - 2022 Advanced Micro Devices, Inc. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publi
-sh, distribute, sublicense, and/or sell
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 copies of the Software, and to permit persons to whom the Software is
 furnished to do so, subject to the following conditions:
 

--- a/amd_openvx_extensions/amd_nn/nn_hip/nn_hip_kernels.cpp
+++ b/amd_openvx_extensions/amd_nn/nn_hip/nn_hip_kernels.cpp
@@ -2191,6 +2191,5 @@ int HipExec_Upsample_Nearest_layer(hipStream_t stream, dim3 globalThreads, dim3 
         hipLaunchKernelGGL(Hip_Upsample_Nearest_layer<__half>, gridDim, localThreads, 0, stream, in, in_offset, in_stride,
             out, out_offset, out_stride);
     }
-
     return VX_SUCCESS;
 }

--- a/amd_openvx_extensions/amd_nn/nn_hip/nn_hip_kernels.cpp
+++ b/amd_openvx_extensions/amd_nn/nn_hip/nn_hip_kernels.cpp
@@ -2158,3 +2158,39 @@ int HipExec_tensor_compare_layer(hipStream_t stream, dim3 globalThreads, dim3 lo
     }
     return VX_SUCCESS;
 }
+
+
+template <typename T>
+__global__ void __attribute__((visibility("default")))
+Hip_Upsample_Nearest_layer(uchar* in, uint in_offset, uint4 in_stride, uchar* out, uint out_offset, uint4 out_stride) {
+
+    uint x = hipBlockDim_x * hipBlockIdx_x + hipThreadIdx_x;
+    uint y = hipBlockDim_y * hipBlockIdx_y + hipThreadIdx_y;
+    uint z = hipBlockDim_z * hipBlockIdx_z + hipThreadIdx_z;
+
+    T value = *(T*)&in[in_offset + x * in_stride.x + y * in_stride.y + z * in_stride.z];
+    out += out_offset + (x << 1) * out_stride.x + (y << 1) * out_stride.y + z * out_stride.z;
+    // read 1 value and write 2x2 output
+    *(T *)&out[0] = value;
+    *(T *)&out[out_stride.x] = value;
+    *(T *)&out[out_stride.y] = value;
+    *(T *)&out[out_stride.y + out_stride.x] = value;
+}
+
+int HipExec_Upsample_Nearest_layer(hipStream_t stream, dim3 globalThreads, dim3 localThreads, vx_enum type, uchar* in,
+    uint in_offset, uint4 in_stride, uchar* out, uint out_offset, uint4 out_stride) {
+
+    dim3 gridDim = dim3(ceil((float)globalThreads.x/localThreads.x),
+                        ceil((float)globalThreads.y/localThreads.y),
+                        ceil((float)globalThreads.z/localThreads.z));
+
+    if (type == VX_TYPE_FLOAT32) {
+        hipLaunchKernelGGL(Hip_Upsample_Nearest_layer<float>, gridDim, localThreads, 0, stream, in, in_offset, in_stride,
+            out, out_offset, out_stride);
+    } else {
+        hipLaunchKernelGGL(Hip_Upsample_Nearest_layer<__half>, gridDim, localThreads, 0, stream, in, in_offset, in_stride,
+            out, out_offset, out_stride);
+    }
+
+    return VX_SUCCESS;
+}


### PR DESCRIPTION
Implementation of vxUpsampleNearestLayer node on HIP backend which is needed for yolov3 models.