### PR TITLE
OpenVX cts- Floating point exception fix

### DIFF
--- a/amd_openvx/openvx/ago/ago_kernel_api.cpp
+++ b/amd_openvx/openvx/ago/ago_kernel_api.cpp
@@ -2266,8 +2266,8 @@ int ovxKernel_LaplacianPyramid(AgoNode * node, AgoKernelCommand cmd)
     }
     else if (cmd == ago_kernel_cmd_validate) {
         // validate parameters
-        vx_uint32 width = node->paramList[0]->u.img.width;
-        vx_uint32 height = node->paramList[0]->u.img.height;
+        vx_float32 width = (vx_float32)node->paramList[0]->u.img.width;
+        vx_float32 height = (vx_float32)node->paramList[0]->u.img.height;
         vx_df_image format = node->paramList[0]->u.img.format;
         if (format != VX_DF_IMAGE_S16 && format != VX_DF_IMAGE_U8)
             return VX_ERROR_INVALID_FORMAT;
@@ -2282,15 +2282,15 @@ int ovxKernel_LaplacianPyramid(AgoNode * node, AgoKernelCommand cmd)
         vx_size levels = node->paramList[1]->u.pyr.levels;
 
         while (levels--) {
-            width *= (vx_uint32) scale;
-            height *= (vx_uint32) scale;
+            width *= scale;
+            height *= scale;
         }
 
         // set output image sizes same as input image size
         vx_meta_format meta;
         meta = &node->metaList[2];
-        meta->data.u.img.width = width;
-        meta->data.u.img.height = height;
+        meta->data.u.img.width = (vx_int32)width;
+        meta->data.u.img.height = (vx_int32)height;
         meta->data.u.img.format = format;
 
         status = VX_SUCCESS;
@@ -2316,8 +2316,8 @@ int ovxKernel_LaplacianReconstruct(AgoNode * node, AgoKernelCommand cmd)
     }
     else if (cmd == ago_kernel_cmd_validate) {
         // validate parameters
-        vx_uint32 width = node->paramList[1]->u.img.width;
-        vx_uint32 height = node->paramList[1]->u.img.height;
+        vx_float32 width = (vx_float32)node->paramList[1]->u.img.width;
+        vx_float32 height = (vx_float32)node->paramList[1]->u.img.height;
         vx_df_image format = node->paramList[1]->u.img.format;
         if (format != VX_DF_IMAGE_S16 && format != VX_DF_IMAGE_U8)
             return VX_ERROR_INVALID_FORMAT;
@@ -2331,14 +2331,14 @@ int ovxKernel_LaplacianReconstruct(AgoNode * node, AgoKernelCommand cmd)
         vx_float32 scale = node->paramList[0]->u.pyr.scale;
         vx_size levels = node->paramList[0]->u.pyr.levels;
         while (levels--) {
-            width /= (vx_uint32) scale;
-            height /= (vx_uint32) scale;
+            width /= scale;
+            height /= scale;
         }
         // set output image sizes same as input image size
         vx_meta_format meta;
         meta = &node->metaList[2];
-        meta->data.u.img.width = width;
-        meta->data.u.img.height = height;
+        meta->data.u.img.width = (vx_int32)width;
+        meta->data.u.img.height = (vx_int32)height;
         meta->data.u.img.format = format;
         status = VX_SUCCESS;
     }
@@ -22513,8 +22513,8 @@ int agoKernel_LaplacianPyramid_DATA_DATA_DATA(AgoNode * node, AgoKernelCommand c
     }
     else if (cmd == ago_kernel_cmd_validate) {
         // validate parameters
-        vx_uint32 width = node->paramList[1]->u.img.width;
-        vx_uint32 height = node->paramList[1]->u.img.height;
+        vx_float32 width = (vx_float32)node->paramList[1]->u.img.width;
+        vx_float32 height = (vx_float32)node->paramList[1]->u.img.height;
         vx_df_image format = node->paramList[1]->u.img.format;
         if (format != VX_DF_IMAGE_S16 && format != VX_DF_IMAGE_U8)
             return VX_ERROR_INVALID_FORMAT;
@@ -22526,15 +22526,15 @@ int agoKernel_LaplacianPyramid_DATA_DATA_DATA(AgoNode * node, AgoKernelCommand c
         vx_float32 scale = node->paramList[2]->u.pyr.scale;
         vx_size levels = node->paramList[2]->u.pyr.levels;
         while (levels--) {
-            width *= (vx_uint32) scale;
-            height *= (vx_uint32) scale;
+            width *= scale;
+            height *= scale;
         }
 
         // set output image sizes same as input image size
         vx_meta_format meta;
         meta = &node->metaList[0];
-        meta->data.u.img.width = width;
-        meta->data.u.img.height = height;
+        meta->data.u.img.width = (vx_uint32)width;
+        meta->data.u.img.height = (vx_uint32)height;
         meta->data.u.img.format = format;
 
         status = VX_SUCCESS;
@@ -22573,8 +22573,8 @@ int agoKernel_LaplacianReconstruct_DATA_DATA_DATA(AgoNode * node, AgoKernelComma
     }
     else if (cmd == ago_kernel_cmd_validate) {
         // validate parameters
-        vx_uint32 width = node->paramList[2]->u.img.width;
-        vx_uint32 height = node->paramList[2]->u.img.height;
+        vx_float32 width = (vx_float32)node->paramList[2]->u.img.width;
+        vx_float32 height = (vx_float32)node->paramList[2]->u.img.height;
         vx_df_image format = node->paramList[2]->u.img.format;
         if (format != VX_DF_IMAGE_S16 && format != VX_DF_IMAGE_U8)
             return VX_ERROR_INVALID_FORMAT;
@@ -22587,14 +22587,14 @@ int agoKernel_LaplacianReconstruct_DATA_DATA_DATA(AgoNode * node, AgoKernelComma
         vx_size levels = node->paramList[1]->u.pyr.levels;
 
         while (levels--) {
-            width /= (vx_uint32) scale;
-            height /= (vx_uint32) scale;
+            width /= scale;
+            height /= scale;
         }
         // set output image sizes same as input image size
         vx_meta_format meta;
         meta = &node->metaList[0];
-        meta->data.u.img.width = width;
-        meta->data.u.img.height = height;
+        meta->data.u.img.width = (vx_uint32)width;
+        meta->data.u.img.height = (vx_uint32)height;
         meta->data.u.img.format = format;
 
         status = VX_SUCCESS;


### PR DESCRIPTION
Changed the data types of width/height to vx_float32 and then cast to vx_uint32 at the end to avoid warning & floating point exception