### PR TITLE
SPACK updates - Turbo JPEG 

### DIFF
--- a/amd_openvx/cmake/FindTurboJpeg.cmake
+++ b/amd_openvx/cmake/FindTurboJpeg.cmake
@@ -25,21 +25,30 @@
 ################################################################################
 find_path(TurboJpeg_INCLUDE_DIRS
     NAMES turbojpeg.h
+    HINTS
+    $ENV{TURBO_JPEG_PATH}/include
     PATHS
+    ${TURBO_JPEG_PATH}/include
     /usr/include/
 )
 mark_as_advanced( TurboJpeg_INCLUDE_DIRS )
 
 find_library( TurboJpeg_LIBRARIES
     NAMES libturbojpeg.so
+    HINTS
+    $ENV{TURBO_JPEG_PATH}/lib
     PATHS
+    ${TURBO_JPEG_PATH}/include
     /usr/lib
 )
 mark_as_advanced( TurboJpeg_LIBRARIES_DIR )
 
 find_path(TurboJpeg_LIBRARIES_DIR
     NAMES libturbojpeg.so
+    HINTS
+    $ENV{TURBO_JPEG_PATH}/lib
     PATHS
+    ${TURBO_JPEG_PATH}/include
     /usr/lib
 )
 

--- a/amd_openvx/cmake/FindTurboJpeg.cmake
+++ b/amd_openvx/cmake/FindTurboJpeg.cmake
@@ -37,8 +37,10 @@ find_library( TurboJpeg_LIBRARIES
     NAMES libturbojpeg.so
     HINTS
     $ENV{TURBO_JPEG_PATH}/lib
+    $ENV{TURBO_JPEG_PATH}/lib64
     PATHS
-    ${TURBO_JPEG_PATH}/include
+    ${TURBO_JPEG_PATH}/lib
+    ${TURBO_JPEG_PATH}/lib64
     /usr/lib
 )
 mark_as_advanced( TurboJpeg_LIBRARIES_DIR )
@@ -47,8 +49,10 @@ find_path(TurboJpeg_LIBRARIES_DIR
     NAMES libturbojpeg.so
     HINTS
     $ENV{TURBO_JPEG_PATH}/lib
+    $ENV{TURBO_JPEG_PATH}/lib64
     PATHS
-    ${TURBO_JPEG_PATH}/include
+    ${TURBO_JPEG_PATH}/lib
+    ${TURBO_JPEG_PATH}/lib64
     /usr/lib
 )
 


### PR DESCRIPTION
@srekolam these updates add an ENV Variable - `TURBO_JPEG_PATH` that could be set or pass `TURBO_JPEG_PATH` as a -D cmake build option. Let me know if this would fix SPACK build.