### PR TITLE
AMD - Float16 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ option(ROCAL            "Build MIVisionX with ROCAL Support"       ON)
 option(LOOM             "Build MIVisionX with LOOM Support"        ON)
 option(GPU_SUPPORT      "Build MIVisionX with GPU Support"         ON)
 option(MIGRAPHX         "Build MIVisionX with MIGraphX Support"    ON)
+option(AMD_FP16_SUPPORT "Build MIVisionX with float16 Support"    OFF)
 
 if(WIN32)
   set(BACKEND "OpenCL")
@@ -120,6 +121,12 @@ message("-- ${Cyan}     -D LOOM=${LOOM} [Turn ON/OFF LOOM Modules (default:ON)]$
 message("-- ${Cyan}     -D GPU_SUPPORT=${GPU_SUPPORT} [Turn ON/OFF GPU support (default:ON)]${ColourReset}")
 message("-- ${Cyan}     -D MIGRAPHX=${MIGRAPHX} [Turn ON/OFF MIGraphX Module (default:ON)]${ColourReset}")
 message("-- ${Cyan}     -D BACKEND=${BACKEND} [Select MIVisionX Backend [options:CPU/OPENCL/HIP](default:HIP)]${ColourReset}")
+message("-- ${Cyan}     -D AMD_FP16_SUPPORT=${AMD_FP16_SUPPORT} [Turn ON/OFF OpenVX FP16 Support (default:OFF)]${ColourReset}")
+
+if(AMD_FP16_SUPPORT)
+  add_definitions(-DAMD_FP16_SUPPORT)
+  message("-- ${Blue}MIVisionX -- -DAMD_FP16_SUPPORT definition added${ColourReset}")
+endif(AMD_FP16_SUPPORT)
 
 add_subdirectory(amd_openvx)
 add_subdirectory(amd_openvx_extensions)

--- a/amd_openvx/openvx/include/vx_ext_amd.h
+++ b/amd_openvx/openvx/include/vx_ext_amd.h
@@ -77,7 +77,6 @@ THE SOFTWARE.
 enum ago_type_public_e {
     /*! \brief AMD data types
     */
-    /*VX_TYPE_FLOAT16             = 0x00F,                     // 16-bit float data type*/
     VX_TYPE_STRING_AMD          = 0x011,                     // scalar data type for string
 
     /*! \brief AMD data structs

--- a/amd_openvx/openvx/include/vx_ext_amd.h
+++ b/amd_openvx/openvx/include/vx_ext_amd.h
@@ -412,6 +412,14 @@ typedef struct {
     amd_kernel_gpu_buffer_update_callback_f gpu_buffer_update_callback_f;
     vx_uint32 gpu_buffer_update_param_index;
 } AgoKernelGpuBufferUpdateInfo;
+
+#if defined(AMD_FLOAT_16_SUPPORT)
+/*! \brief A 16-bit float value.
+ */
+#include <half/half.hpp>
+using half_float::half;
+typedef half vx_float16;
+#endif
 #endif
 
 #ifdef  __cplusplus

--- a/amd_openvx/openvx/include/vx_ext_amd.h
+++ b/amd_openvx/openvx/include/vx_ext_amd.h
@@ -412,7 +412,7 @@ typedef struct {
     vx_uint32 gpu_buffer_update_param_index;
 } AgoKernelGpuBufferUpdateInfo;
 
-#if defined(AMD_FLOAT_16_SUPPORT)
+#if defined(AMD_FP16_SUPPORT)
 /*! \brief A 16-bit float value.
  */
 #include <half/half.hpp>


### PR DESCRIPTION
OpenVX defines float16 with Experimental flag using hfloat - https://github.com/GPUOpen-ProfessionalCompute-Libraries/MIVisionX/blob/9b1c5c487722c8f09ab901727def22e78549e0b6/amd_openvx/openvx/include/VX/vx_types.h#L114

To use C++ half.hpp - turn on `AMD_FP16_SUPPORT`