### PR TITLE
rocAL - add missing header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@
 
 [MIVisionX Documentation](https://gpuopen-professionalcompute-libraries.github.io/MIVisionX/)
 
+## MIVisionX 2.4.0 (unreleased)
+
+### Added
+
+* OpenVX FP16 Support
+
+### Optimizations
+
+* CMakeList Cleanup
+
+### Changed
+
+* rocAL - Changing Python Lib Path
+
+### Fixed
+
+* rocAL bug fix and updates
+
+### Tested Configurations
+
+* Windows `10` / `11`
+* Linux distribution
+  + Ubuntu - `20.04` / `22.04`
+  + CentOS - `7` / `8`
+  + SLES - `15-SP2`
+* ROCm: rocm-core - `5.3.0.50300-63`
+* miopen-hip - `2.18.0.50300-63`
+* miopen-opencl - `2.18.0.50300-63`
+* migraphx - `2.3.0.50300-63`
+* Protobuf - [V3.12.4](https://github.com/protocolbuffers/protobuf/releases/tag/v3.12.4)
+* OpenCV - [4.5.5](https://github.com/opencv/opencv/releases/tag/4.5.5)
+* RPP - [0.97](https://github.com/GPUOpen-ProfessionalCompute-Libraries/rpp/releases/tag/0.97)
+* FFMPEG - [n4.4.2](https://github.com/FFmpeg/FFmpeg/releases/tag/n4.4.2)
+* Dependencies for all the above packages
+* MIVisionX Setup Script - `V2.3.8`
+
+### Known issues
+
+* OpenCV 4.X support for some apps missing
+
 ## MIVisionX 2.3.0
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -434,16 +434,16 @@ Review all notable [changes](CHANGELOG.md#changelog) with the latest release
   + Ubuntu - `20.04` / `22.04`
   + CentOS - `7` / `8`
   + SLES - `15-SP2`
-* ROCm: rocm-core - `5.3.0.50300-36`
-* miopen-hip - `2.18.0.50300-36`
-* miopen-opencl - `2.18.0.50300-36`
-* migraphx - `2.3.0.50300-36`
+* ROCm: rocm-core - `5.3.0.50300-63`
+* miopen-hip - `2.18.0.50300-63`
+* miopen-opencl - `2.18.0.50300-63`
+* migraphx - `2.3.0.50300-63`
 * Protobuf - [V3.12.4](https://github.com/protocolbuffers/protobuf/releases/tag/v3.12.4)
 * OpenCV - [4.5.5](https://github.com/opencv/opencv/releases/tag/4.5.5)
 * RPP - [0.97](https://github.com/GPUOpen-ProfessionalCompute-Libraries/rpp/releases/tag/0.97)
 * FFMPEG - [n4.4.2](https://github.com/FFmpeg/FFmpeg/releases/tag/n4.4.2)
 * Dependencies for all the above packages
-* MIVisionX Setup Script - `V2.3.7`
+* MIVisionX Setup Script - `V2.3.8`
 
 ### Known issues
 

--- a/rocAL/rocAL/include/device/device_manager_hip.h
+++ b/rocAL/rocAL/include/device/device_manager_hip.h
@@ -27,6 +27,7 @@ THE SOFTWARE.
 #include "hip/hip_runtime.h"
 #include <vx_ext_amd.h>
 #include <VX/vx_types.h>
+#include <memory>
 
 struct DeviceResourcesHip {
     hipStream_t hip_stream;


### PR DESCRIPTION
-- rocAL -- Using HIP -- Path:/opt/rocm	Version:5.3.22374	Compiler:clang

Ubuntu 22.04 -- Kapu

* Issue fixed
```
In file included from /home/kiriti/develop/mivisionx-kiriti/MIVisionX/rocAL/rocAL/source/device/device_manager_hip.cpp:27:
/home/kiriti/develop/mivisionx-kiriti/MIVisionX/rocAL/rocAL/./include/device/device_manager_hip.h:56:24: error: ‘shared_ptr’ in namespace ‘std’ does not name a template type
   56 | using pRocalHip = std::shared_ptr<DeviceManagerHip>;
```