### PR TITLE
Remove RPATH/RUNPATH - Adding SKIP RPATH flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,7 +39,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "MIVisionX default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
-# Changes for SWDEV-310152: 
+# Changes for RPATH Removal from Binaries:
 # Since all public interface libraries are present in same folder 
 # RPATH/RUNPATH is not required
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,11 @@ set(ROCM_PATH /opt/rocm CACHE PATH "Default ROCm installation path")
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "MIVisionX default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# Changes for SWDEV-310152: 
+# Since all public interface libraries are present in same folder 
+# RPATH/RUNPATH is not required
+set(CMAKE_SKIP_RPATH TRUE)
 
 # MIVisionX Default Options
 option(ENHANCED_MESSAGE "MIVisionX Enhanced Message Option"        ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,8 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 # Changes for SWDEV-310152: 
 # Since all public interface libraries are present in same folder 
 # RPATH/RUNPATH is not required
-set(CMAKE_SKIP_RPATH TRUE)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+set(CMAKE_SKIP_INSTALL_RPATH TRUE)
 
 # MIVisionX Default Options
 option(ENHANCED_MESSAGE "MIVisionX Enhanced Message Option"        ON)

--- a/amd_openvx_extensions/amd_custom/custom_lib/CMakeLists.txt
+++ b/amd_openvx_extensions/amd_custom/custom_lib/CMakeLists.txt
@@ -33,7 +33,8 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 # Changes for SWDEV-310152: 
 # Since all public interface libraries are present in same folder 
 # RPATH/RUNPATH is not required
-set(CMAKE_SKIP_RPATH TRUE)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+set(CMAKE_SKIP_INSTALL_RPATH TRUE)
 
 # Add Default libdir
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")

--- a/amd_openvx_extensions/amd_custom/custom_lib/CMakeLists.txt
+++ b/amd_openvx_extensions/amd_custom/custom_lib/CMakeLists.txt
@@ -29,7 +29,11 @@ set(ROCM_PATH /opt/rocm CACHE PATH "Default ROCm installation path")
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "MIVisionX default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# Changes for SWDEV-310152: 
+# Since all public interface libraries are present in same folder 
+# RPATH/RUNPATH is not required
+set(CMAKE_SKIP_RPATH TRUE)
 
 # Add Default libdir
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")

--- a/amd_openvx_extensions/amd_custom/custom_lib/CMakeLists.txt
+++ b/amd_openvx_extensions/amd_custom/custom_lib/CMakeLists.txt
@@ -30,7 +30,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "MIVisionX default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
-# Changes for SWDEV-310152: 
+# Changes for RPATH Removal from Binaries:
 # Since all public interface libraries are present in same folder 
 # RPATH/RUNPATH is not required
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)

--- a/apps/cloud_inference/server_app/CMakeLists.txt
+++ b/apps/cloud_inference/server_app/CMakeLists.txt
@@ -33,7 +33,8 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 # Changes for SWDEV-310152: 
 # Since all public interface libraries are present in same folder 
 # RPATH/RUNPATH is not required
-set(CMAKE_SKIP_RPATH TRUE)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+set(CMAKE_SKIP_INSTALL_RPATH TRUE)
 
 # Add Default libdir
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")

--- a/apps/cloud_inference/server_app/CMakeLists.txt
+++ b/apps/cloud_inference/server_app/CMakeLists.txt
@@ -29,7 +29,11 @@ set(ROCM_PATH /opt/rocm CACHE PATH "Default ROCm installation path")
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "MIVisionX default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# Changes for SWDEV-310152: 
+# Since all public interface libraries are present in same folder 
+# RPATH/RUNPATH is not required
+set(CMAKE_SKIP_RPATH TRUE)
 
 # Add Default libdir
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")

--- a/apps/cloud_inference/server_app/CMakeLists.txt
+++ b/apps/cloud_inference/server_app/CMakeLists.txt
@@ -30,7 +30,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "MIVisionX default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
-# Changes for SWDEV-310152: 
+# Changes for RPATH Removal from Binaries:
 # Since all public interface libraries are present in same folder 
 # RPATH/RUNPATH is not required
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)

--- a/apps/dg_test/CMakeLists.txt
+++ b/apps/dg_test/CMakeLists.txt
@@ -29,7 +29,12 @@ set(ROCM_PATH /opt/rocm CACHE PATH "Default ROCm installation path")
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "MIVisionX default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# Changes for SWDEV-310152:
+# Since all public interface libraries are present in same folder
+# RPATH/RUNPATH is not required
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+set(CMAKE_SKIP_INSTALL_RPATH TRUE)
 
 # Add Default libdir
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")

--- a/apps/dg_test/CMakeLists.txt
+++ b/apps/dg_test/CMakeLists.txt
@@ -30,7 +30,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "MIVisionX default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
-# Changes for SWDEV-310152:
+# Changes for RPATH Removal from Binaries:
 # Since all public interface libraries are present in same folder
 # RPATH/RUNPATH is not required
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)

--- a/apps/image_augmentation/CMakeLists.txt
+++ b/apps/image_augmentation/CMakeLists.txt
@@ -40,7 +40,8 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 # Changes for SWDEV-310152: 
 # Since all public interface libraries are present in same folder 
 # RPATH/RUNPATH is not required
-set(CMAKE_SKIP_RPATH TRUE)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+set(CMAKE_SKIP_INSTALL_RPATH TRUE)
 
 # Add Default libdir
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")

--- a/apps/image_augmentation/CMakeLists.txt
+++ b/apps/image_augmentation/CMakeLists.txt
@@ -36,7 +36,11 @@ set(ROCM_PATH /opt/rocm CACHE PATH "Default ROCm installation path")
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "MIVisionX default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# Changes for SWDEV-310152: 
+# Since all public interface libraries are present in same folder 
+# RPATH/RUNPATH is not required
+set(CMAKE_SKIP_RPATH TRUE)
 
 # Add Default libdir
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")

--- a/apps/image_augmentation/CMakeLists.txt
+++ b/apps/image_augmentation/CMakeLists.txt
@@ -37,7 +37,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "MIVisionX default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
-# Changes for SWDEV-310152: 
+# Changes for RPATH Removal from Binaries:
 # Since all public interface libraries are present in same folder 
 # RPATH/RUNPATH is not required
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)

--- a/apps/mivisionx_openvx_classifier/CMakeLists.txt
+++ b/apps/mivisionx_openvx_classifier/CMakeLists.txt
@@ -32,7 +32,11 @@ set(ROCM_PATH /opt/rocm CACHE PATH "Default ROCm installation path")
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "MIVisionX default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# Changes for SWDEV-310152: 
+# Since all public interface libraries are present in same folder 
+# RPATH/RUNPATH is not required
+set(CMAKE_SKIP_RPATH TRUE)
 
 # Add Default libdir
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")

--- a/apps/mivisionx_openvx_classifier/CMakeLists.txt
+++ b/apps/mivisionx_openvx_classifier/CMakeLists.txt
@@ -36,7 +36,8 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 # Changes for SWDEV-310152: 
 # Since all public interface libraries are present in same folder 
 # RPATH/RUNPATH is not required
-set(CMAKE_SKIP_RPATH TRUE)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+set(CMAKE_SKIP_INSTALL_RPATH TRUE)
 
 # Add Default libdir
 set(CMAKE_INSTALL_LIBDIR "lib" CACHE STRING "Library install directory")

--- a/apps/mivisionx_openvx_classifier/CMakeLists.txt
+++ b/apps/mivisionx_openvx_classifier/CMakeLists.txt
@@ -33,7 +33,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "MIVisionX default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
-# Changes for SWDEV-310152: 
+# Changes for RPATH Removal from Binaries:
 # Since all public interface libraries are present in same folder 
 # RPATH/RUNPATH is not required
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)

--- a/model_compiler/python/nnir_to_clib.py
+++ b/model_compiler/python/nnir_to_clib.py
@@ -132,7 +132,8 @@ endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 # Changes for SWDEV-310152: 
 # Since all public interface libraries are present in same folder 
 # RPATH/RUNPATH is not required
-set(CMAKE_SKIP_RPATH TRUE)
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
+set(CMAKE_SKIP_INSTALL_RPATH TRUE)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 

--- a/model_compiler/python/nnir_to_clib.py
+++ b/model_compiler/python/nnir_to_clib.py
@@ -128,7 +128,11 @@ set(ROCM_PATH /opt/rocm CACHE PATH "Default ROCm installation path")
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "mivisionx default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
+# Changes for SWDEV-310152: 
+# Since all public interface libraries are present in same folder 
+# RPATH/RUNPATH is not required
+set(CMAKE_SKIP_RPATH TRUE)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 

--- a/model_compiler/python/nnir_to_clib.py
+++ b/model_compiler/python/nnir_to_clib.py
@@ -129,7 +129,7 @@ if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   set(CMAKE_INSTALL_PREFIX ${ROCM_PATH} CACHE PATH "mivisionx default installation path" FORCE)
 endif(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
-# Changes for SWDEV-310152: 
+# Changes for RPATH Removal from Binaries:
 # Since all public interface libraries are present in same folder 
 # RPATH/RUNPATH is not required
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)


### PR DESCRIPTION
Summary of proposed changes:

- Single version package: add ldconfig, no RPATH/RUNPATH in either binaries or libraries
- Multi version package: use RPATH for binaries, no RPATH/RUNPATH for libraries
- amdclang/clang/hipcc compilers shall not add RPATH/RUNPATH to produced binaries or libraries unless explicitly requested by an option
- Versioning scripts will take care of adding rpath to binaries for multi version package