### PR TITLE
rocAL - changes for classification training convergence

### DIFF
--- a/rocAL/rocAL/include/pipeline/image.h
+++ b/rocAL/rocAL/include/pipeline/image.h
@@ -112,8 +112,8 @@ struct ImageInfo
     uint32_t * get_roi_height() const;
     const std::vector<uint32_t>& get_roi_width_vec() const;
     const std::vector<uint32_t>& get_roi_height_vec() const;
-    const std::vector<uint32_t>& get_original_roi_width_vec() const;
-    const std::vector<uint32_t>& get_original_roi_height_vec() const;
+    const std::vector<uint32_t>& get_original_width_vec() const;
+    const std::vector<uint32_t>& get_original_height_vec() const;
 
 private:
     Type _type = Type::UNKNOWN;//!< image type, whether is virtual image, created from handle or is a regular image
@@ -167,7 +167,7 @@ struct Image
 
     int create(vx_context context);
     void update_image_roi(const std::vector<uint32_t> &width, const std::vector<uint32_t> &height);
-    void update_image_original_roi(const std::vector<uint32_t> &original_width, const std::vector<uint32_t> &original_height);
+    void update_image_original_dims(const std::vector<uint32_t> &original_width, const std::vector<uint32_t> &original_height);
     void reset_image_roi() { _info.reallocate_image_roi_buffers(); }
     // create_from_handle() no internal memory allocation is done here since image's handle should be swapped with external buffers before usage
     int create_from_handle(vx_context context);

--- a/rocAL/rocAL/include/pipeline/image.h
+++ b/rocAL/rocAL/include/pipeline/image.h
@@ -112,8 +112,8 @@ struct ImageInfo
     uint32_t * get_roi_height() const;
     const std::vector<uint32_t>& get_roi_width_vec() const;
     const std::vector<uint32_t>& get_roi_height_vec() const;
-    const std::vector<uint32_t>& get_orig_roi_width_vec() const;
-    const std::vector<uint32_t>& get_orig_roi_height_vec() const;
+    const std::vector<uint32_t>& get_original_roi_width_vec() const;
+    const std::vector<uint32_t>& get_original_roi_height_vec() const;
 
 private:
     Type _type = Type::UNKNOWN;//!< image type, whether is virtual image, created from handle or is a regular image
@@ -126,8 +126,8 @@ private:
     RocalColorFormat _color_fmt;//!< color format of the image
     std::shared_ptr<std::vector<uint32_t>> _roi_width;//!< The actual image width stored in the buffer, it's always smaller than _width/_batch_size. It's created as a vector of pointers to integers, so that if it's passed from one image to another and get updated by one and observed for all.
     std::shared_ptr<std::vector<uint32_t>> _roi_height;//!< The actual image height stored in the buffer, it's always smaller than _height. It's created as a vector of pointers to integers, so that if it's passed from one image to another and get updated by one changes can be observed for all.
-    std::shared_ptr<std::vector<uint32_t>> _orig_roi_width;//!< The actual image width stored in the buffer, it's always smaller than _width/_batch_size. It's created as a vector of pointers to integers, so that if it's passed from one image to another and get updated by one and observed for all.
-    std::shared_ptr<std::vector<uint32_t>> _orig_roi_height;//!< The actual image height stored in the buffer, it's always smaller than _height. It's created as a vector of pointers to integers, so that if it's passed from one image to another and get updated by one changes can be observed for all.
+    std::shared_ptr<std::vector<uint32_t>> _original_roi_width;//!< The original image width decoded by the turbojpeg library before scaling to _roi_width
+    std::shared_ptr<std::vector<uint32_t>> _original_roi_height;//!< The original image height decoded by the turbojpeg library before scaling to _roi_height
 
     void reallocate_image_roi_buffers();
 
@@ -167,7 +167,7 @@ struct Image
 
     int create(vx_context context);
     void update_image_roi(const std::vector<uint32_t> &width, const std::vector<uint32_t> &height);
-    void update_image_orig_roi(const std::vector<uint32_t> &width, const std::vector<uint32_t> &height);
+    void update_image_original_roi(const std::vector<uint32_t> &original_width, const std::vector<uint32_t> &original_height);
     void reset_image_roi() { _info.reallocate_image_roi_buffers(); }
     // create_from_handle() no internal memory allocation is done here since image's handle should be swapped with external buffers before usage
     int create_from_handle(vx_context context);

--- a/rocAL/rocAL/include/pipeline/image.h
+++ b/rocAL/rocAL/include/pipeline/image.h
@@ -112,6 +112,9 @@ struct ImageInfo
     uint32_t * get_roi_height() const;
     const std::vector<uint32_t>& get_roi_width_vec() const;
     const std::vector<uint32_t>& get_roi_height_vec() const;
+    const std::vector<uint32_t>& get_orig_roi_width_vec() const;
+    const std::vector<uint32_t>& get_orig_roi_height_vec() const;
+
 private:
     Type _type = Type::UNKNOWN;//!< image type, whether is virtual image, created from handle or is a regular image
     unsigned _width;//!< image width for a single image in the batch
@@ -123,6 +126,8 @@ private:
     RocalColorFormat _color_fmt;//!< color format of the image
     std::shared_ptr<std::vector<uint32_t>> _roi_width;//!< The actual image width stored in the buffer, it's always smaller than _width/_batch_size. It's created as a vector of pointers to integers, so that if it's passed from one image to another and get updated by one and observed for all.
     std::shared_ptr<std::vector<uint32_t>> _roi_height;//!< The actual image height stored in the buffer, it's always smaller than _height. It's created as a vector of pointers to integers, so that if it's passed from one image to another and get updated by one changes can be observed for all.
+    std::shared_ptr<std::vector<uint32_t>> _orig_roi_width;//!< The actual image width stored in the buffer, it's always smaller than _width/_batch_size. It's created as a vector of pointers to integers, so that if it's passed from one image to another and get updated by one and observed for all.
+    std::shared_ptr<std::vector<uint32_t>> _orig_roi_height;//!< The actual image height stored in the buffer, it's always smaller than _height. It's created as a vector of pointers to integers, so that if it's passed from one image to another and get updated by one changes can be observed for all.
 
     void reallocate_image_roi_buffers();
 
@@ -162,6 +167,7 @@ struct Image
 
     int create(vx_context context);
     void update_image_roi(const std::vector<uint32_t> &width, const std::vector<uint32_t> &height);
+    void update_image_orig_roi(const std::vector<uint32_t> &width, const std::vector<uint32_t> &height);
     void reset_image_roi() { _info.reallocate_image_roi_buffers(); }
     // create_from_handle() no internal memory allocation is done here since image's handle should be swapped with external buffers before usage
     int create_from_handle(vx_context context);

--- a/rocAL/rocAL/include/pipeline/image.h
+++ b/rocAL/rocAL/include/pipeline/image.h
@@ -126,8 +126,8 @@ private:
     RocalColorFormat _color_fmt;//!< color format of the image
     std::shared_ptr<std::vector<uint32_t>> _roi_width;//!< The actual image width stored in the buffer, it's always smaller than _width/_batch_size. It's created as a vector of pointers to integers, so that if it's passed from one image to another and get updated by one and observed for all.
     std::shared_ptr<std::vector<uint32_t>> _roi_height;//!< The actual image height stored in the buffer, it's always smaller than _height. It's created as a vector of pointers to integers, so that if it's passed from one image to another and get updated by one changes can be observed for all.
-    std::shared_ptr<std::vector<uint32_t>> _original_roi_width;//!< The original image width decoded by the turbojpeg library before scaling to _roi_width
-    std::shared_ptr<std::vector<uint32_t>> _original_roi_height;//!< The original image height decoded by the turbojpeg library before scaling to _roi_height
+    std::shared_ptr<std::vector<uint32_t>> _original_width;//!< The original image width decoded by the turbojpeg library before scaling to _roi_width
+    std::shared_ptr<std::vector<uint32_t>> _original_height;//!< The original image height decoded by the turbojpeg library before scaling to _roi_height
 
     void reallocate_image_roi_buffers();
 

--- a/rocAL/rocAL/source/api/rocal_api_augmentation.cpp
+++ b/rocAL/rocAL/source/api/rocal_api_augmentation.cpp
@@ -29,7 +29,7 @@ THE SOFTWARE.
 #include "rocal_api.h"
 #include "image_source_evaluator.h"
 
-#define MAX_ASPECT_RATIO 3.0f
+#define MAX_ASPECT_RATIO 6.0f
 
 RocalImage  ROCAL_API_CALL
 rocalSequenceRearrange(

--- a/rocAL/rocAL/source/api/rocal_api_augmentation.cpp
+++ b/rocAL/rocAL/source/api/rocal_api_augmentation.cpp
@@ -29,6 +29,7 @@ THE SOFTWARE.
 #include "rocal_api.h"
 #include "image_source_evaluator.h"
 
+// Calculated from the largest resize shorter dimension in imagenet validation dataset
 #define MAX_ASPECT_RATIO 6.0f
 
 RocalImage  ROCAL_API_CALL

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
@@ -60,24 +60,19 @@ void ResizeNode::create_node() {
 
 void ResizeNode::update_node() {
     std::vector<uint32_t> src_h_dims, src_w_dims;
-    std::vector<uint32_t> original_h_dims, original_w_dims;
     src_w_dims = _inputs[0]->info().get_roi_width_vec();
     src_h_dims = _inputs[0]->info().get_roi_height_vec();
-    original_w_dims = _inputs[0]->info().get_original_roi_width_vec();
-    original_h_dims = _inputs[0]->info().get_original_roi_height_vec();
+    if (_scaling_mode == RocalResizeScalingMode::ROCAL_SCALING_MODE_NOT_SMALLER) {
+        // Using original width and height instead of the decoded width and height for computing resize shorter dimensions
+        src_w_dims = _inputs[0]->info().get_original_roi_width_vec();
+        src_h_dims = _inputs[0]->info().get_original_roi_height_vec();
+    }
     for (unsigned i = 0; i < _batch_size; i++) {
         _src_width = src_w_dims[i];
         _src_height = src_h_dims[i];
         _dst_width = _out_width;
         _dst_height = _out_height;
-        if (_scaling_mode == RocalResizeScalingMode::ROCAL_SCALING_MODE_NOT_SMALLER) {
-            if(original_w_dims[i] > original_h_dims[i])
-                _dst_width *= (original_w_dims[i] / original_h_dims[i]);
-            else
-                _dst_height *= (original_h_dims[i] / original_w_dims[i]);
-        }
-        else
-            adjust_out_roi_size();
+        adjust_out_roi_size();
         _dst_width = std::min(_dst_width, _outputs[0]->info().width());
         _dst_height = std::min(_dst_height, _outputs[0]->info().height_single());
         _dst_roi_width_vec.push_back(_dst_width);

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
@@ -60,21 +60,21 @@ void ResizeNode::create_node() {
 
 void ResizeNode::update_node() {
     std::vector<uint32_t> src_h_dims, src_w_dims;
-    std::vector<uint32_t> orig_h_dims, orig_w_dims;
+    std::vector<uint32_t> original_h_dims, original_w_dims;
     src_w_dims = _inputs[0]->info().get_roi_width_vec();
     src_h_dims = _inputs[0]->info().get_roi_height_vec();
-    orig_w_dims = _inputs[0]->info().get_orig_roi_width_vec();
-    orig_h_dims = _inputs[0]->info().get_orig_roi_height_vec();
+    original_w_dims = _inputs[0]->info().get_original_roi_width_vec();
+    original_h_dims = _inputs[0]->info().get_original_roi_height_vec();
     for (unsigned i = 0; i < _batch_size; i++) {
         _src_width = src_w_dims[i];
         _src_height = src_h_dims[i];
         _dst_width = _out_width;
         _dst_height = _out_height;
         if (_scaling_mode == RocalResizeScalingMode::ROCAL_SCALING_MODE_NOT_SMALLER) {
-            if(orig_w_dims[i] > orig_h_dims[i])
-                _dst_width = (_dst_width * orig_w_dims[i])/orig_h_dims[i];
+            if(original_w_dims[i] > original_h_dims[i])
+                _dst_width *= (original_w_dims[i] / original_h_dims[i]);
             else
-                _dst_height = (_dst_height * orig_h_dims[i]/orig_w_dims[i]);
+                _dst_height *= (original_h_dims[i] / original_w_dims[i]);
         }
         else
             adjust_out_roi_size();

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
@@ -60,13 +60,9 @@ void ResizeNode::create_node() {
 
 void ResizeNode::update_node() {
     std::vector<uint32_t> src_h_dims, src_w_dims;
-    src_w_dims = _inputs[0]->info().get_roi_width_vec();
-    src_h_dims = _inputs[0]->info().get_roi_height_vec();
-    if (_scaling_mode == RocalResizeScalingMode::ROCAL_SCALING_MODE_NOT_SMALLER) {
-        // Using original width and height instead of the decoded width and height for computing resize shorter dimensions
-        src_w_dims = _inputs[0]->info().get_original_roi_width_vec();
-        src_h_dims = _inputs[0]->info().get_original_roi_height_vec();
-    }
+    // Using original width and height instead of the decoded width and height for computing resize dimensions
+    src_w_dims = _inputs[0]->info().get_original_roi_width_vec();
+    src_h_dims = _inputs[0]->info().get_original_roi_height_vec();
     for (unsigned i = 0; i < _batch_size; i++) {
         _src_width = src_w_dims[i];
         _src_height = src_h_dims[i];

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
@@ -48,7 +48,7 @@ void ResizeNode::create_node() {
      if(width_status != 0 || height_status != 0)
         THROW(" vxAddArrayItems failed in the resize (vxExtrppNode_ResizebatchPD) node: "+ TOSTR(width_status) + "  "+ TOSTR(height_status))
 #if ENABLE_OPENCL
-    // fall back to batch_pd version since there is no tensor implementation for OPENCL
+    // fall back to batch_pd version since there is no tensor implementation for OPENCL    
     _node = vxExtrppNode_ResizebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width, _dst_roi_height, _batch_size);
 #else
    _node = vxExtrppNode_Resizetensor(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width, _dst_roi_height, _interpolation_type, _batch_size);
@@ -83,12 +83,6 @@ void ResizeNode::update_node() {
         _dst_roi_width_vec.push_back(_dst_width);
         _dst_roi_height_vec.push_back(_dst_height);
     }
-    std::cerr<<"\n***************************************** Now Resized dims ***********************************";
-    for (size_t i = 0; i < _batch_size; i++) {
-            std::cerr<<"\n i :: "<<i<<" "<<_dst_roi_width_vec[i]<<" "<<_dst_roi_height_vec[i];
-    }
-    std::cerr<<"\n***************************************** Resized dims ***********************************";
-
     vx_status width_status, height_status;
     width_status = vxCopyArrayRange((vx_array)_dst_roi_width, 0, _batch_size, sizeof(vx_uint32), _dst_roi_width_vec.data(), VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST);
     height_status = vxCopyArrayRange((vx_array)_dst_roi_height, 0, _batch_size, sizeof(vx_uint32), _dst_roi_height_vec.data(), VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST);
@@ -128,7 +122,7 @@ void ResizeNode::adjust_out_roi_size() {
         } else if ((!_dst_height) & _dst_width) {  // Only width is passed
             _dst_height = std::lround(_src_height * (static_cast<float>(_dst_width) / _src_width));
         }
-
+        
         if (has_max_size) {
             if (_max_width) _dst_width = std::min(_dst_width, _max_width);
             if (_max_height) _dst_height = std::min(_dst_height, _max_height);
@@ -142,7 +136,7 @@ void ResizeNode::adjust_out_roi_size() {
         } else if (_scaling_mode == RocalResizeScalingMode::ROCAL_SCALING_MODE_NOT_LARGER) {
             scale = (scale_w > 0 && scale_h > 0) ? std::min(scale_w, scale_h) : ((scale_w > 0) ? scale_w : scale_h);
         }
-
+        
         if (has_max_size) {
             if (_max_width) scale = std::min(scale, static_cast<float>(_max_width) / _src_width);
             if (_max_height) scale = std::min(scale, static_cast<float>(_max_height) / _src_height);

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
@@ -61,8 +61,8 @@ void ResizeNode::create_node() {
 void ResizeNode::update_node() {
     std::vector<uint32_t> src_h_dims, src_w_dims;
     // Using original width and height instead of the decoded width and height for computing resize dimensions
-    src_w_dims = _inputs[0]->info().get_original_roi_width_vec();
-    src_h_dims = _inputs[0]->info().get_original_roi_height_vec();
+    src_w_dims = _inputs[0]->info().get_original_width_vec();
+    src_h_dims = _inputs[0]->info().get_original_height_vec();
     for (unsigned i = 0; i < _batch_size; i++) {
         _src_width = src_w_dims[i];
         _src_height = src_h_dims[i];

--- a/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
+++ b/rocAL/rocAL/source/augmentations/geometry_augmentations/node_resize.cpp
@@ -48,7 +48,7 @@ void ResizeNode::create_node() {
      if(width_status != 0 || height_status != 0)
         THROW(" vxAddArrayItems failed in the resize (vxExtrppNode_ResizebatchPD) node: "+ TOSTR(width_status) + "  "+ TOSTR(height_status))
 #if ENABLE_OPENCL
-    // fall back to batch_pd version since there is no tensor implementation for OPENCL    
+    // fall back to batch_pd version since there is no tensor implementation for OPENCL
     _node = vxExtrppNode_ResizebatchPD(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width, _dst_roi_height, _batch_size);
 #else
    _node = vxExtrppNode_Resizetensor(_graph->get(), _inputs[0]->handle(), _src_roi_width, _src_roi_height, _outputs[0]->handle(), _dst_roi_width, _dst_roi_height, _interpolation_type, _batch_size);
@@ -60,19 +60,35 @@ void ResizeNode::create_node() {
 
 void ResizeNode::update_node() {
     std::vector<uint32_t> src_h_dims, src_w_dims;
+    std::vector<uint32_t> orig_h_dims, orig_w_dims;
     src_w_dims = _inputs[0]->info().get_roi_width_vec();
     src_h_dims = _inputs[0]->info().get_roi_height_vec();
+    orig_w_dims = _inputs[0]->info().get_orig_roi_width_vec();
+    orig_h_dims = _inputs[0]->info().get_orig_roi_height_vec();
     for (unsigned i = 0; i < _batch_size; i++) {
         _src_width = src_w_dims[i];
         _src_height = src_h_dims[i];
         _dst_width = _out_width;
         _dst_height = _out_height;
-        adjust_out_roi_size();
+        if (_scaling_mode == RocalResizeScalingMode::ROCAL_SCALING_MODE_NOT_SMALLER) {
+            if(orig_w_dims[i] > orig_h_dims[i])
+                _dst_width = (_dst_width * orig_w_dims[i])/orig_h_dims[i];
+            else
+                _dst_height = (_dst_height * orig_h_dims[i]/orig_w_dims[i]);
+        }
+        else
+            adjust_out_roi_size();
         _dst_width = std::min(_dst_width, _outputs[0]->info().width());
         _dst_height = std::min(_dst_height, _outputs[0]->info().height_single());
         _dst_roi_width_vec.push_back(_dst_width);
         _dst_roi_height_vec.push_back(_dst_height);
     }
+    std::cerr<<"\n***************************************** Now Resized dims ***********************************";
+    for (size_t i = 0; i < _batch_size; i++) {
+            std::cerr<<"\n i :: "<<i<<" "<<_dst_roi_width_vec[i]<<" "<<_dst_roi_height_vec[i];
+    }
+    std::cerr<<"\n***************************************** Resized dims ***********************************";
+
     vx_status width_status, height_status;
     width_status = vxCopyArrayRange((vx_array)_dst_roi_width, 0, _batch_size, sizeof(vx_uint32), _dst_roi_width_vec.data(), VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST);
     height_status = vxCopyArrayRange((vx_array)_dst_roi_height, 0, _batch_size, sizeof(vx_uint32), _dst_roi_height_vec.data(), VX_WRITE_ONLY, VX_MEMORY_TYPE_HOST);
@@ -112,7 +128,7 @@ void ResizeNode::adjust_out_roi_size() {
         } else if ((!_dst_height) & _dst_width) {  // Only width is passed
             _dst_height = std::lround(_src_height * (static_cast<float>(_dst_width) / _src_width));
         }
-        
+
         if (has_max_size) {
             if (_max_width) _dst_width = std::min(_dst_width, _max_width);
             if (_max_height) _dst_height = std::min(_dst_height, _max_height);
@@ -126,7 +142,7 @@ void ResizeNode::adjust_out_roi_size() {
         } else if (_scaling_mode == RocalResizeScalingMode::ROCAL_SCALING_MODE_NOT_LARGER) {
             scale = (scale_w > 0 && scale_h > 0) ? std::min(scale_w, scale_h) : ((scale_w > 0) ? scale_w : scale_h);
         }
-        
+
         if (has_max_size) {
             if (_max_width) scale = std::min(scale, static_cast<float>(_max_width) / _src_width);
             if (_max_height) scale = std::min(scale, static_cast<float>(_max_height) / _src_height);

--- a/rocAL/rocAL/source/decoders/image/fused_crop_decoder.cpp
+++ b/rocAL/rocAL/source/decoders/image/fused_crop_decoder.cpp
@@ -90,7 +90,7 @@ Decoder::Status FusedCropTJDecoder::decode(unsigned char *input_buffer, size_t i
                       max_decoded_width * planes,
                       max_decoded_height,
                       tjpf,
-                      TJFLAG_FASTDCT, &x1_diff, &crop_width_diff,
+                      TJFLAG_ACCURATEDCT, &x1_diff, &crop_width_diff,
                       _crop_window.x, _crop_window.y, _crop_window.W, _crop_window.H) != 0) {
         WRN("Jpeg image decode failed " + STR(tjGetErrorStr2(m_jpegDecompressor)))
         return Status::CONTENT_DECODE_FAILED;

--- a/rocAL/rocAL/source/decoders/image/turbo_jpeg_decoder.cpp
+++ b/rocAL/rocAL/source/decoders/image/turbo_jpeg_decoder.cpp
@@ -112,7 +112,7 @@ Decoder::Status TJDecoder::decode(unsigned char *input_buffer, size_t input_size
                             max_decoded_width * planes,
                             max_decoded_height,
                             tjpf,
-                            TJFLAG_FASTDCT,
+                            TJFLAG_ACCURATEDCT,
                             crop_width, crop_height) != 0)
 
             {
@@ -142,7 +142,7 @@ Decoder::Status TJDecoder::decode(unsigned char *input_buffer, size_t input_size
                             max_decoded_width * planes,
                             max_decoded_height,
                             tjpf,
-                            TJFLAG_FASTDCT) != 0) {
+                            TJFLAG_ACCURATEDCT) != 0) {
                 // try decode to original dim and scale using OpenCV
                 WRN("Jpeg image decode failed " + STR(tjGetErrorStr2(m_jpegDecompressor)))
                 return Status::CONTENT_DECODE_FAILED;
@@ -194,7 +194,7 @@ Decoder::Status TJDecoder::decode(unsigned char *input_buffer, size_t input_size
                             max_decoded_width * planes,
                             max_decoded_height,
                             tjpf,
-                            TJFLAG_FASTDCT,
+                            TJFLAG_ACCURATEDCT,
                             crop_width, crop_height) != 0)
 
             {
@@ -224,7 +224,7 @@ Decoder::Status TJDecoder::decode(unsigned char *input_buffer, size_t input_size
                             max_decoded_width * planes,
                             actual_decoded_height,
                             tjpf,
-                            TJFLAG_FASTDCT) != 0) {
+                            TJFLAG_ACCURATEDCT) != 0) {
                 WRN("KO::Jpeg image decode failed " + STR(tjGetErrorStr2(m_jpegDecompressor)))
                 return Status::CONTENT_DECODE_FAILED;
             }

--- a/rocAL/rocAL/source/loaders/image/image_loader.cpp
+++ b/rocAL/rocAL/source/loaders/image/image_loader.cpp
@@ -288,7 +288,7 @@ ImageLoader::update_output_image()
     }
     _output_names = _output_decoded_img_info._image_names;
     _output_image->update_image_roi(_output_decoded_img_info._roi_width, _output_decoded_img_info._roi_height);
-
+    _output_image->update_image_orig_roi(_output_decoded_img_info._original_width, _output_decoded_img_info._original_height);
     _circ_buff.pop();
     if (!_loop)
         _remaining_image_count -= _batch_size;

--- a/rocAL/rocAL/source/loaders/image/image_loader.cpp
+++ b/rocAL/rocAL/source/loaders/image/image_loader.cpp
@@ -288,7 +288,7 @@ ImageLoader::update_output_image()
     }
     _output_names = _output_decoded_img_info._image_names;
     _output_image->update_image_roi(_output_decoded_img_info._roi_width, _output_decoded_img_info._roi_height);
-    _output_image->update_image_orig_roi(_output_decoded_img_info._original_width, _output_decoded_img_info._original_height);
+    _output_image->update_image_original_roi(_output_decoded_img_info._original_width, _output_decoded_img_info._original_height);
     _circ_buff.pop();
     if (!_loop)
         _remaining_image_count -= _batch_size;

--- a/rocAL/rocAL/source/loaders/image/image_loader.cpp
+++ b/rocAL/rocAL/source/loaders/image/image_loader.cpp
@@ -288,7 +288,7 @@ ImageLoader::update_output_image()
     }
     _output_names = _output_decoded_img_info._image_names;
     _output_image->update_image_roi(_output_decoded_img_info._roi_width, _output_decoded_img_info._roi_height);
-    _output_image->update_image_original_roi(_output_decoded_img_info._original_width, _output_decoded_img_info._original_height);
+    _output_image->update_image_original_dims(_output_decoded_img_info._original_width, _output_decoded_img_info._original_height);
     _circ_buff.pop();
     if (!_loop)
         _remaining_image_count -= _batch_size;

--- a/rocAL/rocAL/source/loaders/image/image_read_and_decode.cpp
+++ b/rocAL/rocAL/source/loaders/image/image_read_and_decode.cpp
@@ -226,7 +226,27 @@ ImageReadAndDecode::load(unsigned char* buff,
             int original_width, original_height, jpeg_sub_samp;
             if (_decoder[i]->decode_info(_compressed_buff[i].data(), _actual_read_size[i], &original_width, &original_height,
                                          &jpeg_sub_samp) != Decoder::Status::OK) {
-                    continue;
+                    // Substituting the image which failed decoding with other image from the same batch
+                    int j = ((i + 1) != _batch_size) ? _batch_size - 1 : _batch_size - 2;
+                    while ((j >= 0)) 
+                    {
+                        if (_decoder[i]->decode_info(_compressed_buff[j].data(), _actual_read_size[j], &original_width, &original_height,
+                            &jpeg_sub_samp) == Decoder::Status::OK) 
+                        {
+                                _image_names[i] =  _image_names[j];
+                                _compressed_buff[i] =  _compressed_buff[j];
+                                _actual_read_size[i] =  _actual_read_size[j];
+                                _compressed_image_size[i] =  _compressed_image_size[j];
+                                break;                                
+
+                        }
+                        else
+                            j--;
+                        if(j < 0) 
+                        {
+                            THROW("All images in the batch failed decoding\n");
+                        }                                    
+                    }
             }
             _original_height[i] = original_height;
             _original_width[i] = original_width;

--- a/rocAL/rocAL/source/parameters/parameter_rocal_crop.cpp
+++ b/rocAL/rocAL/source/parameters/parameter_rocal_crop.cpp
@@ -53,8 +53,8 @@ void RocalCropParam::fill_crop_dims() {
             cropw_arr_val[img_idx] = (crop_w <= in_width[img_idx] && crop_w > 0) ? crop_w : in_width[img_idx];
             croph_arr_val[img_idx] = (crop_h <= in_height[img_idx] && crop_h > 0) ? crop_h : in_height[img_idx];
             if (_is_fixed_crop) {
-                x1_arr_val[img_idx] = static_cast<size_t>(_crop_anchor[0] * (in_width[img_idx] - cropw_arr_val[img_idx]));
-                y1_arr_val[img_idx] = static_cast<size_t>(_crop_anchor[1] * (in_height[img_idx] - croph_arr_val[img_idx]));
+                x1_arr_val[img_idx] = static_cast<size_t>(std::nearbyintf(_crop_anchor[0] * (in_width[img_idx] - cropw_arr_val[img_idx])));
+                y1_arr_val[img_idx] = static_cast<size_t>(std::nearbyintf(_crop_anchor[1] * (in_height[img_idx] - croph_arr_val[img_idx])));
             } else {
               x1_arr_val[img_idx] = (x1 >= in_width[img_idx]) ? 0 : x1;
               y1_arr_val[img_idx] = (y1 >= in_height[img_idx]) ? 0 : y1;

--- a/rocAL/rocAL/source/pipeline/image.cpp
+++ b/rocAL/rocAL/source/pipeline/image.cpp
@@ -81,6 +81,16 @@ const std::vector<uint32_t>& ImageInfo::get_roi_height_vec() const
     return *_roi_height;
 }
 
+const std::vector<uint32_t>& ImageInfo::get_orig_roi_width_vec() const
+{
+    return *_orig_roi_width;
+}
+
+const std::vector<uint32_t>& ImageInfo::get_orig_roi_height_vec() const
+{
+    return *_orig_roi_height;
+}
+
 
 unsigned ImageInfo::get_roi_width(int image_batch_idx) const
 {
@@ -104,6 +114,8 @@ ImageInfo::reallocate_image_roi_buffers()
 {
     _roi_height = std::make_shared<std::vector<uint32_t>>(_batch_size);
     _roi_width = std::make_shared<std::vector<uint32_t>>(_batch_size);
+    _orig_roi_height = std::make_shared<std::vector<uint32_t>>(_batch_size);
+    _orig_roi_width = std::make_shared<std::vector<uint32_t>>(_batch_size);
     for(unsigned i = 0; i < _batch_size; i++)
     {
         _roi_height->at(i) = height_single();
@@ -174,6 +186,23 @@ void Image::update_image_roi(const std::vector<uint32_t> &width, const std::vect
 
     }
 }
+
+void Image::update_image_orig_roi(const std::vector<uint32_t> &width, const std::vector<uint32_t> &height)
+{
+    if(width.size() != height.size())
+        THROW("Batch size of image height and width info does not match")
+
+    if(width.size() != info().batch_size())
+        THROW("The batch size of actual image height and width different from image batch size "+ TOSTR(width.size())+ " != " +  TOSTR(info().batch_size()))
+    if(! _info._orig_roi_width || !_info._orig_roi_height)
+        THROW("ROI width or ROI height vector not created")
+    for(unsigned i = 0; i < info().batch_size(); i++)
+    {
+        _info._orig_roi_width->at(i) = width[i];
+        _info._orig_roi_height->at(i)= height[i];
+    }
+}
+
 
 Image::~Image()
 {

--- a/rocAL/rocAL/source/pipeline/image.cpp
+++ b/rocAL/rocAL/source/pipeline/image.cpp
@@ -81,12 +81,12 @@ const std::vector<uint32_t>& ImageInfo::get_roi_height_vec() const
     return *_roi_height;
 }
 
-const std::vector<uint32_t>& ImageInfo::get_original_roi_width_vec() const
+const std::vector<uint32_t>& ImageInfo::get_original_width_vec() const
 {
     return *_original_roi_width;
 }
 
-const std::vector<uint32_t>& ImageInfo::get_original_roi_height_vec() const
+const std::vector<uint32_t>& ImageInfo::get_original_height_vec() const
 {
     return *_original_roi_height;
 }
@@ -187,7 +187,7 @@ void Image::update_image_roi(const std::vector<uint32_t> &width, const std::vect
     }
 }
 
-void Image::update_image_original_roi(const std::vector<uint32_t> &original_width, const std::vector<uint32_t> &original_height)
+void Image::update_image_original_dims(const std::vector<uint32_t> &original_width, const std::vector<uint32_t> &original_height)
 {
     if(original_width.size() != original_height.size())
         THROW("Batch size of image height and width info does not match")

--- a/rocAL/rocAL/source/pipeline/image.cpp
+++ b/rocAL/rocAL/source/pipeline/image.cpp
@@ -81,14 +81,14 @@ const std::vector<uint32_t>& ImageInfo::get_roi_height_vec() const
     return *_roi_height;
 }
 
-const std::vector<uint32_t>& ImageInfo::get_orig_roi_width_vec() const
+const std::vector<uint32_t>& ImageInfo::get_original_roi_width_vec() const
 {
-    return *_orig_roi_width;
+    return *_original_roi_width;
 }
 
-const std::vector<uint32_t>& ImageInfo::get_orig_roi_height_vec() const
+const std::vector<uint32_t>& ImageInfo::get_original_roi_height_vec() const
 {
-    return *_orig_roi_height;
+    return *_original_roi_height;
 }
 
 
@@ -114,8 +114,8 @@ ImageInfo::reallocate_image_roi_buffers()
 {
     _roi_height = std::make_shared<std::vector<uint32_t>>(_batch_size);
     _roi_width = std::make_shared<std::vector<uint32_t>>(_batch_size);
-    _orig_roi_height = std::make_shared<std::vector<uint32_t>>(_batch_size);
-    _orig_roi_width = std::make_shared<std::vector<uint32_t>>(_batch_size);
+    _original_roi_height = std::make_shared<std::vector<uint32_t>>(_batch_size);
+    _original_roi_width = std::make_shared<std::vector<uint32_t>>(_batch_size);
     for(unsigned i = 0; i < _batch_size; i++)
     {
         _roi_height->at(i) = height_single();
@@ -187,22 +187,21 @@ void Image::update_image_roi(const std::vector<uint32_t> &width, const std::vect
     }
 }
 
-void Image::update_image_orig_roi(const std::vector<uint32_t> &width, const std::vector<uint32_t> &height)
+void Image::update_image_original_roi(const std::vector<uint32_t> &original_width, const std::vector<uint32_t> &original_height)
 {
-    if(width.size() != height.size())
+    if(original_width.size() != original_height.size())
         THROW("Batch size of image height and width info does not match")
 
-    if(width.size() != info().batch_size())
-        THROW("The batch size of actual image height and width different from image batch size "+ TOSTR(width.size())+ " != " +  TOSTR(info().batch_size()))
-    if(! _info._orig_roi_width || !_info._orig_roi_height)
+    if(original_width.size() != info().batch_size())
+        THROW("The batch size of actual image height and width different from image batch size "+ TOSTR(original_width.size())+ " != " +  TOSTR(info().batch_size()))
+    if(!_info._original_roi_width || !_info._original_roi_height)
         THROW("ROI width or ROI height vector not created")
     for(unsigned i = 0; i < info().batch_size(); i++)
     {
-        _info._orig_roi_width->at(i) = width[i];
-        _info._orig_roi_height->at(i)= height[i];
+        _info._original_roi_width->at(i) = original_width[i];
+        _info._original_roi_height->at(i)= original_height[i];
     }
 }
-
 
 Image::~Image()
 {

--- a/rocAL/rocAL/source/pipeline/image.cpp
+++ b/rocAL/rocAL/source/pipeline/image.cpp
@@ -83,12 +83,12 @@ const std::vector<uint32_t>& ImageInfo::get_roi_height_vec() const
 
 const std::vector<uint32_t>& ImageInfo::get_original_width_vec() const
 {
-    return *_original_roi_width;
+    return *_original_width;
 }
 
 const std::vector<uint32_t>& ImageInfo::get_original_height_vec() const
 {
-    return *_original_roi_height;
+    return *_original_height;
 }
 
 
@@ -114,8 +114,8 @@ ImageInfo::reallocate_image_roi_buffers()
 {
     _roi_height = std::make_shared<std::vector<uint32_t>>(_batch_size);
     _roi_width = std::make_shared<std::vector<uint32_t>>(_batch_size);
-    _original_roi_height = std::make_shared<std::vector<uint32_t>>(_batch_size);
-    _original_roi_width = std::make_shared<std::vector<uint32_t>>(_batch_size);
+    _original_height = std::make_shared<std::vector<uint32_t>>(_batch_size);
+    _original_width = std::make_shared<std::vector<uint32_t>>(_batch_size);
     for(unsigned i = 0; i < _batch_size; i++)
     {
         _roi_height->at(i) = height_single();
@@ -194,12 +194,12 @@ void Image::update_image_original_dims(const std::vector<uint32_t> &original_wid
 
     if(original_width.size() != info().batch_size())
         THROW("The batch size of actual image height and width different from image batch size "+ TOSTR(original_width.size())+ " != " +  TOSTR(info().batch_size()))
-    if(!_info._original_roi_width || !_info._original_roi_height)
+    if(!_info._original_width || !_info._original_height)
         THROW("ROI width or ROI height vector not created")
     for(unsigned i = 0; i < info().batch_size(); i++)
     {
-        _info._original_roi_width->at(i) = original_width[i];
-        _info._original_roi_height->at(i)= original_height[i];
+        _info._original_width->at(i) = original_width[i];
+        _info._original_height->at(i)= original_height[i];
     }
 }
 

--- a/rocAL/rocAL_pybind/amd/rocal/decoders.py
+++ b/rocAL/rocAL_pybind/amd/rocal/decoders.py
@@ -232,6 +232,7 @@ def image_slice(*inputs, file_root='', path='', annotations_file='', shard_id=0,
 
     reader = Pipeline._current_pipeline._reader
     #Reader -> Randon BBox Crop -> ImageDecoderSlice
+    #Random crop parameters taken from pytorch's RandomResizedCrop default function arguments
     #TODO:To pass the crop co-ordinates from random_bbox_crop to image_slice 
     #in tensor branch integration, 
     #for now calling partial decoder to match SSD training outer API's .

--- a/rocAL/rocAL_pybind/amd/rocal/decoders.py
+++ b/rocAL/rocAL_pybind/amd/rocal/decoders.py
@@ -225,7 +225,7 @@ def image_random_crop(*inputs, user_feature_key_map=None, path='', file_root='',
 
 def image_slice(*inputs, file_root='', path='', annotations_file='', shard_id=0, num_shards=1, random_shuffle=False, affine=True, axes=None,
                 axis_names="WH", bytes_per_sample_hint=0, device_memory_padding=16777216, device_memory_padding_jpeg2k=0, 
-                host_memory_padding=8388608, random_aspect_ratio=[0.8, 1.25], random_area=[0.08, 1.0], num_attempts=100,
+                host_memory_padding=8388608, random_aspect_ratio=[0.75, 1.33333], random_area=[0.08, 1.0], num_attempts=100,
                 host_memory_padding_jpeg2k=0, hybrid_huffman_threshold=1000000, memory_stats=False, normalized_anchor=True, 
                 normalized_shape=True, output_type=types.RGB, preserve=False, seed=1, split_stages=False, use_chunk_allocator=False, 
                 use_fast_idct=False, device=None, decode_size_policy=types.USER_GIVEN_SIZE_ORIG, max_decoded_width=1000, max_decoded_height=1000):


### PR DESCRIPTION
Added changes required for classification training convergence

1. Added patch to compute resize dimensions using original image dimensions instead of decoded dimensions
2. Increased the max aspect ratio used for creating resize output buffer to 6 for accommodating the largest resize dimension in ImageNet validation dataset
3. Changed the DCT algorithm used in TurboJpeg decoder to accurate DCT algorithm which is the default algorithm used in DALI and PIL libraries
4. Added patch for using the correct rounding mode when calculating the crop dimensions
5. Added an else condition to choose another image in the same batch when the image fails decoding using TurboJpeg decoder
6. Changed the random aspect ratio range to the values used in torchvision's RandomResizedCrop function