### PR TITLE
CMakeLists - Avoid RPATH removal from binaries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,10 +78,6 @@ if(APPLE)
   set(ROCAL OFF)
   set(BACKEND "CPU")
   message("-- ${Magenta}Apple macOS Detected -- GPU Support turned OFF${ColourReset}")
-else()
-  # Changes for RPATH Removal from Binaries:
-  set(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)
-  set(CMAKE_SKIP_INSTALL_RPATH TRUE)
 endif()
 
 if(NOT DEFINED BACKEND)


### PR DESCRIPTION
Proposed Changes:
- Cleaning up RPATH removal logic
- This was added as part of Adding SKIP RPATH flag (#995) and Enhanced for BUILD_DEV Option (#1010)
- Since #995 changes are reverted, this change also required to be reverted.