### PR TITLE
remove shuffle_time from rocal timing

### DIFF
--- a/rocAL/rocAL/include/pipeline/commons.h
+++ b/rocAL/rocAL/include/pipeline/commons.h
@@ -95,7 +95,6 @@ struct Timing
     long long unsigned label_load_time= 0;
     long long unsigned bb_load_time= 0;
     long long unsigned mask_load_time = 0;
-    long long unsigned shuffle_time = 0;
     long long unsigned video_read_time= 0;
     long long unsigned video_decode_time= 0;
     long long unsigned video_process_time= 0;

--- a/rocAL/rocAL/include/readers/image/caffe2_lmdb_record_reader.h
+++ b/rocAL/rocAL/include/readers/image/caffe2_lmdb_record_reader.h
@@ -67,7 +67,7 @@ public:
     int close() override;
 
     Caffe2LMDBRecordReader();
-    unsigned long long get_shuffle_time() override {return 0;}
+
 private:
     //! opens the folder containnig the images
     Reader::Status Caffe2_LMDB_reader();
@@ -108,7 +108,6 @@ private:
     void read_image(unsigned char* buff, std::string file_name);
     void read_image_names();
     std::map <std::string, uint> _image_record_starting;
-    TimingDBG _shuffle_time;
     int _open_env = 1;
     int rc;
     MDB_env* _read_mdb_env;

--- a/rocAL/rocAL/include/readers/image/caffe_lmdb_record_reader.h
+++ b/rocAL/rocAL/include/readers/image/caffe_lmdb_record_reader.h
@@ -66,7 +66,7 @@ public:
     int close() override;
 
     CaffeLMDBRecordReader();
-    unsigned long long get_shuffle_time() override {return 0;}
+
 private:
     //! opens the folder containnig the images
     Reader::Status folder_reading();
@@ -110,7 +110,6 @@ private:
     void read_image(unsigned char* buff, std::string _file_name);
     void read_image_names();
     std::map <std::string, uint> _image_record_starting;
-    TimingDBG _shuffle_time;
     int _open_env = 1;
     int rc;
     void open_env_for_read_image();

--- a/rocAL/rocAL/include/readers/image/cifar10_data_reader.h
+++ b/rocAL/rocAL/include/readers/image/cifar10_data_reader.h
@@ -62,7 +62,6 @@ public:
     CIFAR10DataReader();
 
     unsigned get_file_index() { return _last_file_idx;}
-    unsigned long long get_shuffle_time() override {return 0;}
 
 private:
     //! opens the folder containing the images

--- a/rocAL/rocAL/include/readers/image/coco_file_source_reader.h
+++ b/rocAL/rocAL/include/readers/image/coco_file_source_reader.h
@@ -59,7 +59,6 @@ public:
     std::string id() override { return _last_id;};
 
     unsigned count_items() override;
-    unsigned long long get_shuffle_time() override {return _shuffle_time.get_timing();};
 
     ~COCOFileSourceReader() override;
 
@@ -104,5 +103,4 @@ private:
     void incremenet_file_id() { _file_id++; }
     void replicate_last_image_to_fill_last_shard();
     void replicate_last_batch_to_pad_partial_shard();
-    TimingDBG _shuffle_time;
 };

--- a/rocAL/rocAL/include/readers/image/file_source_reader.h
+++ b/rocAL/rocAL/include/readers/image/file_source_reader.h
@@ -60,7 +60,6 @@ public:
     ~FileSourceReader() override;
 
     int close() override;
-    unsigned long long get_shuffle_time() override {return _shuffle_time.get_timing();};
 
     FileSourceReader();
 
@@ -97,6 +96,5 @@ private:
     void incremenet_file_id() { _file_id++; }
     void replicate_last_image_to_fill_last_shard();
     void replicate_last_batch_to_pad_partial_shard();
-    TimingDBG _shuffle_time;
 };
 

--- a/rocAL/rocAL/include/readers/image/mxnet_recordio_reader.h
+++ b/rocAL/rocAL/include/readers/image/mxnet_recordio_reader.h
@@ -63,7 +63,7 @@ public:
     int close() override;
 
     MXNetRecordIOReader();
-    unsigned long long get_shuffle_time() override {return 0;}
+
 private:
     //! opens the folder containnig the images
     Reader::Status record_reading();
@@ -108,6 +108,5 @@ private:
     const uint32_t _kMagic = 0xced7230a;
     int64_t _seek_pos, _data_size_to_read;
     ImageRecordIOHeader _hdr;
-    TimingDBG _shuffle_time;
 };
 

--- a/rocAL/rocAL/include/readers/image/reader.h
+++ b/rocAL/rocAL/include/readers/image/reader.h
@@ -149,8 +149,5 @@ public:
     //! Returns the number of items remained in this resource
     virtual unsigned count_items() = 0;
     
-    //! return shuffle_time if applicable
-    virtual unsigned long long get_shuffle_time() = 0;
-
     virtual ~Reader() = default;
 };

--- a/rocAL/rocAL/include/readers/image/tf_record_reader.h
+++ b/rocAL/rocAL/include/readers/image/tf_record_reader.h
@@ -61,7 +61,6 @@ public:
     std::string id() override { return _last_id;};
 
     unsigned count_items() override;
-    unsigned long long get_shuffle_time() override {return _shuffle_time.get_timing();};
 
     ~TFRecordReader() override;
 
@@ -115,5 +114,4 @@ private:
     Reader::Status read_image(unsigned char* buff, std::string record_file_name, uint file_size);
     Reader::Status read_image_names(std::ifstream &file_contents, uint file_size);
     std::map <std::string, uint> _image_record_starting;
-    TimingDBG _shuffle_time;
 };

--- a/rocAL/rocAL/include/readers/video/sequence_file_source_reader.h
+++ b/rocAL/rocAL/include/readers/video/sequence_file_source_reader.h
@@ -60,7 +60,6 @@ public:
     ~SequenceFileSourceReader() override;
 
     int close() override;
-    unsigned long long get_shuffle_time() override {return _shuffle_time.get_timing();};
 
     SequenceFileSourceReader();
 
@@ -105,6 +104,5 @@ private:
     void incremenet_sequence_id() { _sequence_id++; }
     void replicate_last_sequence_to_fill_last_shard();
     void replicate_last_batch_to_pad_partial_shard();
-    TimingDBG _shuffle_time;
 };
 

--- a/rocAL/rocAL/include/readers/video/video_file_source_reader.h
+++ b/rocAL/rocAL/include/readers/video/video_file_source_reader.h
@@ -51,8 +51,6 @@ public:
 
     ~VideoFileSourceReader() override;
 
-    unsigned long long get_shuffle_time() override { return _shuffle_time.get_timing(); };
-
     VideoFileSourceReader();
 private:
     std::string _folder_path;
@@ -88,6 +86,5 @@ private:
     void replicate_last_sequence_to_fill_last_shard();
     void replicate_last_batch_to_pad_partial_shard();
     VideoReader::Status create_sequence_info();
-    TimingDBG _shuffle_time;
 };
 #endif

--- a/rocAL/rocAL/include/readers/video/video_reader.h
+++ b/rocAL/rocAL/include/readers/video/video_reader.h
@@ -113,9 +113,6 @@ public:
     //! Returns the number of items remained in this resource
     virtual unsigned count_items() = 0;
 
-    //! return shuffle_time if applicable
-    virtual unsigned long long get_shuffle_time() = 0;
-
     virtual ~VideoReader() = default;
 };
 #endif

--- a/rocAL/rocAL/source/api/rocal_api_info.cpp
+++ b/rocAL/rocAL/source/api/rocal_api_info.cpp
@@ -120,7 +120,6 @@ TimingInfo
 {
     auto context = static_cast<Context *>(p_context);
     auto info = context->timing();
-    // INFO("shuffle time "+ TOSTR(info.shuffle_time)); to display time taken for shuffling dataset
     // INFO("bbencode time "+ TOSTR(info.bb_process_time)); //to display time taken for bbox encoder
     if (context->master_graph->is_video_loader())
         return {info.video_read_time, info.video_decode_time, info.video_process_time, info.copy_to_output};

--- a/rocAL/rocAL/source/loaders/image/image_read_and_decode.cpp
+++ b/rocAL/rocAL/source/loaders/image/image_read_and_decode.cpp
@@ -51,7 +51,6 @@ ImageReadAndDecode::timing()
     Timing t;
     t.image_decode_time = _decode_time.get_timing();
     t.image_read_time = _file_load_time.get_timing();
-    t.shuffle_time = _reader->get_shuffle_time();
     return t;
 }
 

--- a/rocAL/rocAL/source/loaders/video/video_read_and_decode.cpp
+++ b/rocAL/rocAL/source/loaders/video/video_read_and_decode.cpp
@@ -51,7 +51,6 @@ VideoReadAndDecode::timing()
     Timing t;
     t.video_decode_time = _decode_time.get_timing();
     t.video_read_time = _file_load_time.get_timing();
-    t.shuffle_time = _video_reader->get_shuffle_time();
     return t;
 }
 

--- a/rocAL/rocAL/source/readers/image/caffe2_lmdb_record_reader.cpp
+++ b/rocAL/rocAL/source/readers/image/caffe2_lmdb_record_reader.cpp
@@ -34,8 +34,7 @@ THE SOFTWARE.
 using namespace std;
 namespace filesys = boost::filesystem;
 
-Caffe2LMDBRecordReader::Caffe2LMDBRecordReader():
-_shuffle_time("shuffle_time", DBG_TIMING)
+Caffe2LMDBRecordReader::Caffe2LMDBRecordReader()
 {
     _src_dir = nullptr;
     _sub_dir = nullptr;
@@ -79,10 +78,8 @@ Reader::Status Caffe2LMDBRecordReader::initialize(ReaderConfig desc)
         }
     }
     //shuffle dataset if set
-    _shuffle_time.start();
     if( ret==Reader::Status::OK && _shuffle)
         std::random_shuffle(_file_names.begin(), _file_names.end());
-    _shuffle_time.end();
 
     return ret;
 
@@ -133,10 +130,8 @@ Caffe2LMDBRecordReader::release()
 
 void Caffe2LMDBRecordReader::reset()
 {
-    _shuffle_time.start();
     if(_shuffle)
         std::random_shuffle(_file_names.begin(), _file_names.end());
-    _shuffle_time.end();
     _read_counter = 0;
     _curr_file_idx = 0;
 }

--- a/rocAL/rocAL/source/readers/image/caffe_lmdb_record_reader.cpp
+++ b/rocAL/rocAL/source/readers/image/caffe_lmdb_record_reader.cpp
@@ -37,8 +37,7 @@ using caffe_protos::Datum;
 
 namespace filesys = boost::filesystem;
 
-CaffeLMDBRecordReader::CaffeLMDBRecordReader():
-_shuffle_time("shuffle_time", DBG_TIMING)
+CaffeLMDBRecordReader::CaffeLMDBRecordReader()
 {
     _sub_dir = nullptr;
     _curr_file_idx = 0;
@@ -82,10 +81,8 @@ Reader::Status CaffeLMDBRecordReader::initialize(ReaderConfig desc)
         }
     }
     //shuffle dataset if set
-    _shuffle_time.start();
     if( ret==Reader::Status::OK && _shuffle)
         std::random_shuffle(_file_names.begin(), _file_names.end());
-    _shuffle_time.end();
 
     return ret;
 
@@ -142,10 +139,8 @@ int CaffeLMDBRecordReader::release()
 
 void CaffeLMDBRecordReader::reset()
 {
-    _shuffle_time.start();
     if (_shuffle)
         std::random_shuffle(_file_names.begin(), _file_names.end());
-    _shuffle_time.end();
     _read_counter = 0;
     _curr_file_idx = 0;
 }

--- a/rocAL/rocAL/source/readers/image/coco_file_source_reader.cpp
+++ b/rocAL/rocAL/source/readers/image/coco_file_source_reader.cpp
@@ -32,8 +32,7 @@ THE SOFTWARE.
 namespace filesys = boost::filesystem;
 #define USE_STDIO_FILE 0
 
-COCOFileSourceReader::COCOFileSourceReader():
-_shuffle_time("shuffle_time", DBG_TIMING)
+COCOFileSourceReader::COCOFileSourceReader()
 {
     _src_dir = nullptr;
     _sub_dir = nullptr;
@@ -88,10 +87,8 @@ Reader::Status COCOFileSourceReader::initialize(ReaderConfig desc)
         }
     }
     //shuffle dataset if set
-    _shuffle_time.start();
     if (ret == Reader::Status::OK && _shuffle)
         std::random_shuffle(_file_names.begin(), _file_names.end());
-    _shuffle_time.end();
     return ret;
 }
 

--- a/rocAL/rocAL/source/readers/image/file_source_reader.cpp
+++ b/rocAL/rocAL/source/readers/image/file_source_reader.cpp
@@ -28,8 +28,7 @@ THE SOFTWARE.
 
 namespace filesys = boost::filesystem;
 
-FileSourceReader::FileSourceReader():
-_shuffle_time("shuffle_time", DBG_TIMING)
+FileSourceReader::FileSourceReader()
 {
     _src_dir = nullptr;
     _sub_dir = nullptr;
@@ -73,12 +72,10 @@ Reader::Status FileSourceReader::initialize(ReaderConfig desc)
         }
     }
     //shuffle dataset if set
-    _shuffle_time.start();
     if( ret==Reader::Status::OK && _shuffle)
         std::random_shuffle(_file_names.begin(), _file_names.end());
-    _shuffle_time.end();
-    return ret;
 
+    return ret;
 }
 
 void FileSourceReader::incremenet_read_ptr()
@@ -152,9 +149,7 @@ FileSourceReader::release()
 
 void FileSourceReader::reset()
 {
-    _shuffle_time.start();
     if (_shuffle) std::random_shuffle(_file_names.begin(), _file_names.end());
-    _shuffle_time.end();
     _read_counter = 0;
     _curr_file_idx = 0;
 }

--- a/rocAL/rocAL/source/readers/image/mxnet_recordio_reader.cpp
+++ b/rocAL/rocAL/source/readers/image/mxnet_recordio_reader.cpp
@@ -36,8 +36,7 @@ namespace filesys = boost::filesystem;
 
 using namespace std;
 
-MXNetRecordIOReader::MXNetRecordIOReader():
-_shuffle_time("shuffle_time", DBG_TIMING)
+MXNetRecordIOReader::MXNetRecordIOReader()
 {
     _src_dir = nullptr;
     _entity = nullptr;
@@ -79,10 +78,8 @@ Reader::Status MXNetRecordIOReader::initialize(ReaderConfig desc)
         }
     }
     //shuffle dataset if set
-    _shuffle_time.start();
     if( ret==Reader::Status::OK && _shuffle)
         std::random_shuffle(_file_names.begin(), _file_names.end());
-    _shuffle_time.end();
 
     return ret;
 
@@ -127,10 +124,8 @@ int MXNetRecordIOReader::release()
 
 void MXNetRecordIOReader::reset()
 {
-    _shuffle_time.start();
     if (_shuffle)
         std::random_shuffle(_file_names.begin(), _file_names.end());
-    _shuffle_time.end();
     _read_counter = 0;
     _curr_file_idx = 0;
 }

--- a/rocAL/rocAL/source/readers/image/tf_record_reader.cpp
+++ b/rocAL/rocAL/source/readers/image/tf_record_reader.cpp
@@ -34,8 +34,7 @@ THE SOFTWARE.
 
 namespace filesys = boost::filesystem;
 
-TFRecordReader::TFRecordReader():
-    _shuffle_time("shuffle_time", DBG_TIMING)
+TFRecordReader::TFRecordReader()
 {
     _src_dir = nullptr;
     _sub_dir = nullptr;
@@ -84,10 +83,8 @@ Reader::Status TFRecordReader::initialize(ReaderConfig desc)
         }
     }
     //shuffle dataset if set
-    _shuffle_time.start();
     if (ret == Reader::Status::OK && _shuffle)
         std::random_shuffle(_file_names.begin(), _file_names.end());
-    _shuffle_time.end();
     return ret;
 }
 
@@ -135,10 +132,8 @@ int TFRecordReader::release()
 
 void TFRecordReader::reset()
 {
-    _shuffle_time.start();
     if (_shuffle)
         std::random_shuffle(_file_names.begin(), _file_names.end());
-    _shuffle_time.end();
     _read_counter = 0;
     _curr_file_idx = 0;
 }

--- a/rocAL/rocAL/source/readers/video/sequence_file_source_reader.cpp
+++ b/rocAL/rocAL/source/readers/video/sequence_file_source_reader.cpp
@@ -28,7 +28,7 @@ THE SOFTWARE.
 
 namespace filesys = boost::filesystem;
 
-SequenceFileSourceReader::SequenceFileSourceReader() : _shuffle_time("shuffle_time", DBG_TIMING)
+SequenceFileSourceReader::SequenceFileSourceReader()
 {
     _src_dir = nullptr;
     _sub_dir = nullptr;
@@ -82,10 +82,9 @@ Reader::Status SequenceFileSourceReader::initialize(ReaderConfig desc)
     }
 
     //shuffle dataset if set
-    _shuffle_time.start();
     if (ret == Reader::Status::OK && _shuffle)
         std::random_shuffle(_sequence_frame_names.begin(), _sequence_frame_names.end());
-    _shuffle_time.end();
+
     for(auto && seq : _sequence_frame_names)
     {
         _frame_names.insert(_frame_names.end(), seq.begin(), seq.end());
@@ -157,10 +156,9 @@ int SequenceFileSourceReader::release()
 
 void SequenceFileSourceReader::reset()
 {
-    _shuffle_time.start();
     if (_shuffle)
         std::random_shuffle(_sequence_frame_names.begin(), _sequence_frame_names.end());
-    _shuffle_time.end();
+
     _read_counter = 0;
     _curr_file_idx = 0;
 }

--- a/rocAL/rocAL/source/readers/video/video_file_source_reader.cpp
+++ b/rocAL/rocAL/source/readers/video/video_file_source_reader.cpp
@@ -29,7 +29,7 @@ namespace filesys = boost::filesystem;
 
 
 #ifdef ROCAL_VIDEO
-VideoFileSourceReader::VideoFileSourceReader() : _shuffle_time("shuffle_time", DBG_TIMING)
+VideoFileSourceReader::VideoFileSourceReader()
 {
     _curr_sequence_idx = 0;
     _loop = false;
@@ -79,10 +79,9 @@ VideoReader::Status VideoFileSourceReader::initialize(VideoReaderConfig desc)
         }
     }
     //shuffle dataset if set
-    _shuffle_time.start();
     if (ret == VideoReader::Status::OK && _shuffle)
         std::random_shuffle(_sequences.begin(), _sequences.end());
-    _shuffle_time.end();
+
     return ret;
 }
 


### PR DESCRIPTION
Shuffle time is not very significant. It was added for debugging and removing since it won't be used