### PR TITLE
Remove old doc build step

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,9 +148,6 @@ else()
   message("-- ${Cyan}ROCAL Module turned OFF by user option -D ROCAL=OFF ${ColourReset}")
 endif()
 
-# install MIVisionX docs -- {ROCM_PATH}/${CMAKE_INSTALL_DATADIR}/doc/mivisionx/
-install(FILES docs/README.md DESTINATION ${CMAKE_INSTALL_DATADIR}/doc/mivisionx)
-
 # set package information
 set(CPACK_PACKAGE_VERSION       ${VERSION})
 set(CPACK_PACKAGE_NAME          "mivisionx")


### PR DESCRIPTION
since Read the Docs is now directly taking the README.md from the root, the docs/README.md no longer exists

closes https://github.com/GPUOpen-ProfessionalCompute-Libraries/MIVisionX/issues/1071