### PR TITLE
Documentation - Update dependabot configurations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,10 @@ updates:
     open-pull-requests-limit: 10
     schedule:
       interval: "daily"
+    target-branch: "develop"
+    labels:
+      - "docs"
+      - "dependencies"
+      - "noCI"
+    reviewers:
+      - "samjwu"


### PR DESCRIPTION
target develop branch for PRs by dependabot instead of default branch (currently master)

add labels related to Read the Docs
- docs: PRs are related to documentation
- dependencies: PRs are for documentation requirements
- noCI: the CI for Read the Docs are separate from math library CI

add doc team as reviewers for dependabot PRs