### PR TITLE
rocAL - Setup Updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 * RPP - [1.2.0](https://github.com/GPUOpen-ProfessionalCompute-Libraries/rpp/releases/tag/1.2.0)
 * FFMPEG - [n4.4.2](https://github.com/FFmpeg/FFmpeg/releases/tag/n4.4.2)
 * Dependencies for all the above packages
-* MIVisionX Setup Script - `V2.5.3`
+* MIVisionX Setup Script - `V2.5.4`
 
 ### Known issues
 

--- a/MIVisionX-setup.py
+++ b/MIVisionX-setup.py
@@ -30,7 +30,7 @@ else:
 __author__ = "Kiriti Nagesh Gowda"
 __copyright__ = "Copyright 2018 - 2023, AMD ROCm MIVisionX"
 __license__ = "MIT"
-__version__ = "2.5.3"
+__version__ = "2.5.4"
 __maintainer__ = "Kiriti Nagesh Gowda"
 __email__ = "mivisionx.support@amd.com"
 __status__ = "Shipping"
@@ -485,7 +485,7 @@ else:
                   linuxCMake+' ../; make -j4; sudo make install)')
         # PyBind11
         os.system('sudo -v')
-        os.system('pip install pytest==3.1')
+        os.system('pip install pytest==7.3.1')
         os.system('(cd '+deps_dir+'; git clone -b '+pybind11Version+' https://github.com/pybind/pybind11; cd pybind11; mkdir build; cd build; ' +
                   linuxCMake+' -DDOWNLOAD_CATCH=ON -DDOWNLOAD_EIGEN=ON ../; make -j4; sudo make install)')
         # CuPy Install

--- a/README.md
+++ b/README.md
@@ -467,7 +467,7 @@ Review all notable [changes](CHANGELOG.md#changelog) with the latest release
 * RPP - [1.2.0](https://github.com/GPUOpen-ProfessionalCompute-Libraries/rpp/releases/tag/1.2.0)
 * FFMPEG - [n4.4.2](https://github.com/FFmpeg/FFmpeg/releases/tag/n4.4.2)
 * Dependencies for all the above packages
-* MIVisionX Setup Script - `V2.5.3`
+* MIVisionX Setup Script - `V2.5.4`
 
 ### Known issues
 


### PR DESCRIPTION
Failure on Ubuntu 20.04
```
s.py", line 22, in <module>
    import _pytest.outcomes
ModuleNotFoundError: No module named '_pytest.outcomes'
```