### PR TITLE
Stop generating PDF on Read the Docs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 sphinx:
    configuration: docs/conf.py
 
-formats: [htmlzip, pdf, epub]
+formats: [htmlzip]
 
 python:
    install:


### PR DESCRIPTION
Problem: Read the Docs (RTD) build is breaking when trying to generate Latex PDF

Solution: Disable this to get RTD building again for the develop and master branches

Note: RTD PR builds only make the HTML documentation, which is why they are passing RTD CI