### PR TITLE
Documentation - Doxygen warning fixes

### DIFF
--- a/amd_openvx/openvx/include/VX/vx_api.h
+++ b/amd_openvx/openvx/include/VX/vx_api.h
@@ -159,7 +159,7 @@ VX_API_ENTRY vx_enum VX_API_CALL vxRegisterUserStruct(vx_context context, vx_siz
  * \brief Registers user-defined structures to the context, and associates a name to it.
  * \param [in] context     The reference to the implementation context.
  * \param [in] size        The size of user struct in bytes.
- * \param [in] *type_name  Pointer to the '\0' terminated string that identifies the
+ * \param [in] type_name   Pointer to the '\0' terminated string that identifies the
  *                         user struct type. The string is copied by the function so
  *                         that it stays the property of the caller. NULL means that
  *                         the user struct is not named. The length of the string
@@ -177,8 +177,8 @@ VX_API_ENTRY vx_enum VX_API_CALL vxRegisterUserStructWithName(vx_context context
 /*!
  * \brief Returns the name of the user-defined structure associated with the enumeration given.
  * \param [in] context     The reference to the implementation context.
+ * \param [out] user_struct_type  Name of the user struct
  * \param [in] type_name   The enumeration value of the user struct
- * \param [out] name_size  Name of the user struct
  * \param [in] name_size   The size of allocated buffer pointed to by type_name
  * \return A <tt>\ref vx_status_e</tt> enumeration.
  * \retval VX_SUCCESS user_struct_type was valid, and name was found and returned

--- a/amd_openvx/openvx/include/vx_ext_amd.h
+++ b/amd_openvx/openvx/include/vx_ext_amd.h
@@ -41,7 +41,13 @@ THE SOFTWARE.
  * \ingroup group_amd
  */
 #define AGO_TARGET_AFFINITY_CPU 0x0010 // CPU
+/*! \brief AMD target affinity enumerations for AgoTargetAffinityInfo.device_type
+ * \ingroup group_amd
+ */
 #define AGO_TARGET_AFFINITY_GPU 0x0020 // GPU
+/*! \brief AMD target affinity enumerations for AgoTargetAffinityInfo.device_type
+ * \ingroup group_amd
+ */
 #define AGO_TARGET_AFFINITY_APU 0x0030 // APU
 
 /*! \brief AMD internal parameters. [TODO: This needs to be moved to ago_internal.h]

--- a/amd_openvx_extensions/amd_custom/include/vx_amd_custom.h
+++ b/amd_openvx_extensions/amd_custom/include/vx_amd_custom.h
@@ -34,8 +34,6 @@ THE SOFTWARE.
  */
 
 /*! \brief The type enumeration lists all NN extension types.
- * \ingroup group_cnn
- * \ingroup group_amd_nn
  * \ingroup group_amd_custom
  */
 enum vx_amd_custom_type_e
@@ -44,8 +42,6 @@ enum vx_amd_custom_type_e
 };
 
 /*! \brief Input parameters for a convolution operation.
- * \ingroup group_cnn
- * \ingroup group_amd_nn
  * \ingroup group_amd_custom
  */
 typedef struct _vx_amd_custom_params_t
@@ -58,7 +54,7 @@ typedef struct _vx_amd_custom_params_t
  * \param [in] graph The handle to the graph.
  * \param [in] inputs The input tensor data.
  * \param [in] function custom funtion enum.
- * \param [in] array for user specified custom_parameters.
+ * \param [in] custom_parameters for user specified custom_parameters.
  * \param [out] outputs The output tensor data.
  * \return <tt> vx_node</tt>.
  * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a

--- a/amd_openvx_extensions/amd_nn/include/vx_amd_nn.h
+++ b/amd_openvx_extensions/amd_nn/include/vx_amd_nn.h
@@ -36,150 +36,139 @@ THE SOFTWARE.
 /*! \brief [Graph] Creates a Batch Normalization Layer Node.
  * \ingroup group_amd_nn
  * \param [in] graph The handle to the graph.
- * \param [in] inputs The input tensor data.
- * \param [in] inputs The mean tensor data.
- * \param [in] inputs The variance tensor data.
- * \param [in] inputs The scale tensor data.
- * \param [in] inputs The bias tensor data.
- * \param [in] inputs The eps vx_float32 data.
- * \param [out] outputs The output tensor data.
+ * \param [in] input The input tensor data.
+ * \param [in] mean The mean tensor data.
+ * \param [in] variance The variance tensor data.
+ * \param [in] scale The scale tensor data.
+ * \param [in] bias The bias tensor data.
+ * \param [in] eps The eps vx_float32 data.
+ * \param [out] output The output tensor data.
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
-VX_API_ENTRY vx_node VX_API_CALL vxBatchNormalizationLayer(vx_graph graph, vx_tensor inputs, vx_tensor mean, vx_tensor variance, vx_tensor scale, vx_tensor bias, vx_float32 eps, vx_tensor output);
+VX_API_ENTRY vx_node VX_API_CALL vxBatchNormalizationLayer(vx_graph graph, vx_tensor input, vx_tensor mean, vx_tensor variance, vx_tensor scale, vx_tensor bias, vx_float32 eps, vx_tensor output);
 
 /*! \brief [Graph] Creates a Scale Layer Node.
  * \ingroup group_amd_nn
  * \param [in] graph The handle to the graph.
- * \param [in] inputs The input tensor data.
- * \param [in] inputs The scale tensor data.
- * \param [in] inputs The bias tensor data.
- * \param [out] outputs The output tensor data.
+ * \param [in] input The input tensor data.
+ * \param [in] scale The scale tensor data.
+ * \param [in] bias The bias tensor data.
+ * \param [out] output The output tensor data.
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
-VX_API_ENTRY vx_node VX_API_CALL vxScaleLayer(vx_graph graph, vx_tensor inputs, vx_tensor scale, vx_tensor bias, vx_tensor output);
+VX_API_ENTRY vx_node VX_API_CALL vxScaleLayer(vx_graph graph, vx_tensor input, vx_tensor scale, vx_tensor bias, vx_tensor output);
 
 /*! \brief [Graph] Creates a Argmax Layer Node.
  * \ingroup group_amd_nn
  * \param [in] graph The handle to the graph.
- * \param [in] inputs The input tensor data.
- * \param [out] outputs The output tensor data.
+ * \param [in] input The input tensor data.
+ * \param [out] output The output tensor data.
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
 VX_API_ENTRY vx_node VX_API_CALL vxArgmaxLayer(vx_graph graph, vx_tensor input, vx_reference output);
 
 /*! \brief [Graph] Creates a Image to Tensor Node.
  * \ingroup group_amd_nn
  * \param [in] graph The handle to the graph.
- * \param [in] inputs The input tensor data.
- * \param [out] outputs The output tensor data.
- * \param [in] inputs The a vx_float32 data.
- * \param [in] inputs The b vx_float32 data.
- * \param [in] inputs The reverse channel order vx_bool data.
+ * \param [in] input The input tensor data.
+ * \param [out] output The output tensor data.
+ * \param [in] a The a vx_float32 data.
+ * \param [in] b The b vx_float32 data.
+ * \param [in] reverse_channel_order The reverse channel order vx_bool data.
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
 VX_API_ENTRY vx_node VX_API_CALL vxConvertImageToTensorNode(vx_graph graph, vx_image input, vx_tensor output, vx_float32 a, vx_float32 b, vx_bool reverse_channel_order);
 
 /*! \brief [Graph] Creates a Tensor to Image Node.
  * \ingroup group_amd_nn
  * \param [in] graph The handle to the graph.
- * \param [in] inputs The input tensor data.
- * \param [out] outputs The output tensor data.
- * \param [in] inputs The a vx_float32 data.
- * \param [in] inputs The b vx_float32 data.
- * \param [in] inputs The reverse channel order vx_bool data.
+ * \param [in] input The input tensor data.
+ * \param [out] output The output tensor data.
+ * \param [in] a The a vx_float32 data.
+ * \param [in] b The b vx_float32 data.
+ * \param [in] reverse_channel_order The reverse channel order vx_bool data.
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
 VX_API_ENTRY vx_node VX_API_CALL vxConvertTensorToImageNode(vx_graph graph, vx_tensor input, vx_image output, vx_float32 a, vx_float32 b, vx_bool reverse_channel_order);
 
 /*! \brief [Graph] Creates a Concat Layer Node.
  * \ingroup group_amd_nn
  * \param [in] graph The handle to the graph.
- * \param [out] outputs The output tensor data.
- * \param [in] inputs The input 1 tensor data.
- * \param [in] inputs The input 2 tensor data.
- * \param [in] inputs The input 3 tensor data.
- * \param [in] inputs The input 4 tensor data.
- * \param [in] inputs The input 5 tensor data.
- * \param [in] inputs The input 6 tensor data.
- * \param [in] inputs The input 7 tensor data.
+ * \param [out] output The output tensor data.
+ * \param [in] input1 The input 1 tensor data.
+ * \param [in] input2 The input 2 tensor data.
+ * \param [in] input3 The input 3 tensor data.
+ * \param [in] input4 The input 4 tensor data.
+ * \param [in] input5 The input 5 tensor data.
+ * \param [in] input6 The input 6 tensor data.
+ * \param [in] input7 The input 7 tensor data.
+ * \param [in] input8 The input 8 tensor data.
+ * \param [in] axis The axis vx_int32 data.
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
 VX_API_ENTRY vx_node VX_API_CALL vxConcatLayer(vx_graph graph, vx_tensor output, vx_tensor input1, vx_tensor input2, vx_tensor input3, vx_tensor input4, vx_tensor input5, vx_tensor input6, vx_tensor input7, vx_tensor input8, vx_int32 axis);
 
 /*! \brief [Graph] Creates a Slice Layer Node.
  * \ingroup group_amd_nn
  * \param [in] graph The handle to the graph.
- * \param [in] inputs The input tensor data.
- * \param [out] inputs The output 1 tensor data.
- * \param [out] inputs The output 2 tensor data.
+ * \param [in] input The input tensor data.
+ * \param [out] output1 The output 1 tensor data.
+ * \param [out] output2 The output 2 tensor data.
+ * \param [out] output3 The output 3 tensor data.
+ * \param [out] output4 The output 4 tensor data.
+ * \param [out] output5 The output 5 tensor data.
+ * \param [out] output6 The output 6 tensor data.
+ * \param [out] output7 The output 7 tensor data.
+ * \param [out] output8 The output 8 tensor data.
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
 VX_API_ENTRY vx_node VX_API_CALL vxSliceLayer(vx_graph graph, vx_tensor input, vx_tensor output1, vx_tensor output2, vx_tensor output3, vx_tensor output4, vx_tensor output5, vx_tensor output6, vx_tensor output7, vx_tensor output8);
 
 /*! \brief [Graph] Creates a Convolutional Network Upsampling Layer Node.
  * \ingroup group_amd_nn
- * \details Upsampling is done on the width and height dimensions of the <tt>\ref vx_tensor</tt>. Therefore, we use here the term x for the width dimension and y for the height dimension.\n
- * The Upsampling accept input images as tensors of several types. They always output resized images as float32 tensors.
- * This function supports 4D and 3D tensors as input and output. 4D tensors are for batches of images, 3D tensors for individual images.
- * Upsampling use resize method NEAREST_NEIGHBOR.
+ * \details Upsampling is done on the width and height dimensions of the <tt>\ref vx_tensor</tt>. Therefore, we use here the term x for the width dimension and y for the height dimension. The Upsampling accept input images as tensors of several types. They always output resized images as float32 tensors. This function supports 4D and 3D tensors as input and output. 4D tensors are for batches of images, 3D tensors for individual images. Upsampling use resize method NEAREST_NEIGHBOR.
  * \param [in] graph The handle to the graph.
- * \param [in] inputs The input tensor data.
- * \param [out] outputs The output tensor data. Output will have the same number of dimensions as input. Output tensor data type must be same as the inputs. The width and height dimensions of output must be integer multiple of input. The batch and channel dimensions of output and input must be same.
+ * \param [in] input The input tensor data.
+ * \param [out] output The output tensor data. Output will have the same number of dimensions as input. Output tensor data type must be same as the inputs. The width and height dimensions of output must be integer multiple of input. The batch and channel dimensions of output and input must be same.
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
 VX_API_ENTRY vx_node VX_API_CALL vxUpsampleNearestLayer(vx_graph graph, vx_tensor input, vx_tensor output);
 
 /*! \brief [Graph] Creates a Convolutional Network Reshape Layer Node.
  * \ingroup group_amd_nn
- * \details Reshaping is done with alias if available (output tensor will point to input tensor memory). Otherwise it will do a copy.\n
- * This function supports 4D tensors as input and output.
+ * \details Reshaping is done with alias if available (output tensor will point to input tensor memory). Otherwise it will do a copy. This function supports 4D tensors as input and output.
  * \param [in] graph The handle to the graph.
- * \param [in] inputs The input tensor data.
- * \param [out] outputs The output tensor data. Output will have the same number of dimensions as input. Output tensor data type must be same as the inputs. The width and height dimensions of output must be integer multiple of input. The batch and channel dimensions of output and input must be same.
+ * \param [in] input The input tensor data.
+ * \param [out] output The output tensor data. Output will have the same number of dimensions as input. Output tensor data type must be same as the inputs. The width and height dimensions of output must be integer multiple of input. The batch and channel dimensions of output and input must be same.
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
 VX_API_ENTRY vx_node VX_API_CALL vxReshapeLayer(vx_graph graph, vx_tensor input, vx_tensor output);
 
 /*! \brief [Graph] Creates a Permute Layer Node.
  * \ingroup group_amd_nn
- * \details Permute is done if the output tensor dimensions change. Otherwise it will do a copy.\n
- * This function supports 4D tensors as input and output.
+ * \details Permute is done if the output tensor dimensions change. Otherwise it will do a copy. This function supports 4D tensors as input and output.
  * \param [in] graph The handle to the graph.
  * \param [in] input The input tensor data.
  * \param [in] order The required output tensor dimensions.
- * @note Order takes values:
- * - '0' : 0,1,2,3 (eg:nchw->nchw)
- * - '1' : 0,2,3,1 (eg:nchw->nhwc)
- *
+ * @note Order takes values: - '0' : 0,1,2,3 (eg:nchw->nchw) - '1' : 0,2,3,1 (eg:nchw->nhwc)
  * \param [out] output The output tensor data. Output will have the same number of dimensions as input. Output tensor data type must be same as the inputs. The width, height, batch and channel dimensions of output can be rearranged, but value must be the same as input.
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
 VX_API_ENTRY vx_node VX_API_CALL vxPermuteLayer(vx_graph graph, vx_tensor input, vx_array order, vx_tensor output);
 
 /*! \brief [Graph] Creates a Prior Box Layer Node.
  * \ingroup group_amd_nn
- * \details Prior box gives the coordinates of the bounding boxes for an image.
- * This function supports 4D tensors as input and 3D tensor as output.
+ * \details Prior box gives the coordinates of the bounding boxes for an image. This function supports 4D tensors as input and 3D tensor as output.
  * \param [in] graph The handle to the graph.
  * \param [in] input_1 The input tensor data (output of the previous layer)
  * \param [in] input_2 The input tensor data (image data)
@@ -188,52 +177,45 @@ VX_API_ENTRY vx_node VX_API_CALL vxPermuteLayer(vx_graph graph, vx_tensor input,
  * \param [in] flip Input indicating whether aspect ratio can be flipped. Can take values 1(true)/0(false)
  * \param [in] clip Input indicating whether bounding box coordinates should be within [0,1]. Can take values 1(true)/0(false)
  * \param [in] offset Float value to give an offset for each bounding box
- * \param [out] outputs The output tensor data. Output tensor data type must be float. The batch dimensions of output and input must be same. The channel dimensions of the output will be 2. The 3rd dimension will depend on number of boxes.
- * \param [in] maxSize The size for the first prior (optional)
+ * \param [out] output The output tensor data. Output tensor data type must be float. The batch dimensions of output and input must be same. The channel dimensions of the output will be 2. The 3rd dimension will depend on number of boxes.
  * \param [in] variance The variance of each prior (optional)
+ * \param [in] maxSize The size for the first prior (optional)
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
-VX_API_ENTRY vx_node VX_API_CALL vxPriorBoxLayer(vx_graph graph, vx_tensor input_1, vx_tensor input_2, vx_float32 minSize, vx_array aspect_ratio, vx_int32 flip, vx_int32 clip,
-                                                 vx_float32 offset, vx_tensor output, vx_array variance, vx_float32 maxSize);
+VX_API_ENTRY vx_node VX_API_CALL vxPriorBoxLayer(vx_graph graph, vx_tensor input_1, vx_tensor input_2, vx_float32 minSize, vx_array aspect_ratio, vx_int32 flip, vx_int32 clip, vx_float32 offset, vx_tensor output, vx_array variance, vx_float32 maxSize);
 
 /*! \brief [Graph] Creates a Crop Layer Node.
  * \ingroup group_amd_nn
- * \details Cropping is done on the dimensions of the input vx_tensor to fit the dimensions of the reference tensor.
- * This function supports 4D tensors as input and ouput. The type of the tensor can be either float32 or float16.
+ * \details Cropping is done on the dimensions of the input vx_tensor to fit the dimensions of the reference tensor. This function supports 4D tensors as input and ouput. The type of the tensor can be either float32 or float16.
  * \param [in] graph The handle to the graph.
  * \param [in] input The input tensor data.
  * \param [in] ref The reference tensor data.
  * \param [out] output The cropped tensor data.
- * \param [axis] The dimensions including and trailing 'axis' are cropped. [n x c x h x w]
- * \param [offset1] The offset to set the shift for dimension n.
- * \param [offset2] The offset to set the shift for dimension c.
- * \param [offset3] The offset to set the shift for dimension h.
- * \param [offset4] The offset to set the shift for dimension w.
+ * \param [in] axis The dimensions including and trailing 'axis' are cropped. [n x c x h x w]
+ * \param [in] offset1 The offset to set the shift for dimension n.
+ * \param [in] offset2 The offset to set the shift for dimension c.
+ * \param [in] offset3 The offset to set the shift for dimension h.
+ * \param [in] offset4 The offset to set the shift for dimension w.
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
 VX_API_ENTRY vx_node VX_API_CALL vxCropLayer(vx_graph graph, vx_tensor input, vx_tensor ref, vx_tensor output, vx_scalar axis, vx_scalar offset1, vx_scalar offset2, vx_scalar offset3, vx_scalar offset4);
 
 /*! \brief [Graph] Creates a Crop_And_Resize Layer Node.
  * \ingroup group_amd_nn
- * \details Cropping and Resizing is done on the width and height dimensions of the <tt>\ref vx_tensor</tt>. Like Upsampling Layer Node, we use the term x for the width dimension and y for the height dimension.\n
- * This function supports 4D tensors as input and ouput. The type of the tensor can be either float32 or float16.
- * There are two modes for the resize: NEAREST_NEIGHBOR(mode = 0, default) and BILINEAR_INTERPOLATION(mode = 1).
+ * \details Cropping and Resizing is done on the width and height dimensions of the <tt>\ref vx_tensor</tt>. Like Upsampling Layer Node, we use the term x for the width dimension and y for the height dimension. This function supports 4D tensors as input and ouput. The type of the tensor can be either float32 or float16. There are two modes for the resize: NEAREST_NEIGHBOR(mode = 0, default) and BILINEAR_INTERPOLATION(mode = 1).
  * \param [in] graph The handle to the graph.
- * \param [in] inputs The input tensor data.
- * \param [out] outputs The output tensor data. Output will have the same number of dimensions as input. Output tensor data type must be same as the inputs.
- * \param [x_coord] x_coord The x coordinate of the upper left point that will be cropped.
- * \param [y_coord] y_coord The y coordinate of the upper left point that will be cropped.
- * \param [width] width The width of the area that will be cropped.
- * \param [height] height The height of the are that will be cropped.
- * \param [scaleFactor] scaleFactor The scale factor that will be used to resize the cropped tensor.
- * \param [mode] mode The mode to decide which method will be used for the resize.
+ * \param [in] input The input tensor data.
+ * \param [out] output The output tensor data. Output will have the same number of dimensions as input. Output tensor data type must be same as the inputs.
+ * \param [in] x_coord The x coordinate of the upper left point that will be cropped.
+ * \param [in] y_coord The y coordinate of the upper left point that will be cropped.
+ * \param [in] width The width of the area that will be cropped.
+ * \param [in] height The height of the are that will be cropped.
+ * \param [in] scaleFactor The scale factor that will be used to resize the cropped tensor.
+ * \param [in] mode The mode to decide which method will be used for the resize.
  * \return <tt> vx_node</tt>.
- * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a
- * successful creation should be checked using <tt>\ref vxGetStatus</tt>.
+ * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
 VX_API_ENTRY vx_node VX_API_CALL vxCropAndResizeLayer(vx_graph graph, vx_tensor input, vx_tensor output, vx_scalar x_coord, vx_scalar y_coord, vx_scalar width, vx_scalar height, vx_scalar scaleFactor, vx_scalar mode);
 
@@ -243,9 +225,7 @@ VX_API_ENTRY vx_node VX_API_CALL vxCropAndResizeLayer(vx_graph graph, vx_tensor 
  * This function supports 4D tensors as input and ouput. The type of the tensor can be either float32 or float16.
  * \param [in] graph The handle to the graph.
  * \param [in] input The first input tensor data.
- * \param [in] input2 The second input tensor data. The dimensions and sizes of input2 match those of input1, unless the vx_tensor of one or more dimensions in input2 is 1.
- *                    In this case, those dimensions are treated as if this tensor was expanded to match the size of the corresponding dimension of input1, and data was duplicated on all terms in that dimension.
- *                    After this expansion, the dimensions will be equal. The data type must match the data type of input1.
+ * \param [in] input2 The second input tensor data. The dimensions and sizes of input2 match those of input1, unless the vx_tensor of one or more dimensions in input2 is 1. In this case, those dimensions are treated as if this tensor was expanded to match the size of the corresponding dimension of input1, and data was duplicated on all terms in that dimension. After this expansion, the dimensions will be equal. The data type must match the data type of input1.
  * \param [out] output The output tensor data with the same dimensions as the input tensor data.
  * \return <tt> vx_node</tt>.
  * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
@@ -254,13 +234,10 @@ VX_API_ENTRY vx_node VX_API_CALL vxTensorMinNode(vx_graph graph, vx_tensor input
 
 /*! \brief [Graph] Creates a Tensor_Max Layer Node.
  * \ingroup group_amd_nn
- * \details Performs element-wise max on element values in the input <tt>\ref vx_tensor</tt>.
- * This function supports 4D tensors as input and ouput. The type of the tensor can be either float32 or float16.
+ * \details Performs element-wise max on element values in the input <tt>\ref vx_tensor</tt>. This function supports 4D tensors as input and ouput. The type of the tensor can be either float32 or float16.
  * \param [in] graph The handle to the graph.
  * \param [in] input The first input tensor data.
- * \param [in] input2 The second input tensor data. The dimensions and sizes of input2 match those of input1, unless the vx_tensor of one or more dimensions in input2 is 1.
- *                    In this case, those dimensions are treated as if this tensor was expanded to match the size of the corresponding dimension of input1, and data was duplicated on all terms in that dimension.
- *                    After this expansion, the dimensions will be equal. The data type must match the data type of input1.
+ * \param [in] input2 The second input tensor data. The dimensions and sizes of input2 match those of input1, unless the vx_tensor of one or more dimensions in input2 is 1. In this case, those dimensions are treated as if this tensor was expanded to match the size of the corresponding dimension of input1, and data was duplicated on all terms in that dimension. After this expansion, the dimensions will be equal. The data type must match the data type of input1.
  * \param [out] output The output tensor data with the same dimensions as the input tensor data.
  * \return <tt> vx_node</tt>.
  * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
@@ -269,8 +246,7 @@ VX_API_ENTRY vx_node VX_API_CALL vxTensorMaxNode(vx_graph graph, vx_tensor input
 
 /*! \brief [Graph] Creates a Detection Output Layer Node.
  * \ingroup group_amd_nn
- * \details Gives the details of the detected ouutputs in an image with their label, confidence and the bounding box coordinates.
- * This function supports three 4D tensors as input and one 4D tensor as ouput. The type of the tensor can be either float32 or float16.
+ * \details Gives the details of the detected ouutputs in an image with their label, confidence and the bounding box coordinates. This function supports three 4D tensors as input and one 4D tensor as ouput. The type of the tensor can be either float32 or float16.
  * \param [in] graph The handle to the graph.
  * \param [in] input1 The first input tensor data (location values).
  * \param [in] input2 The second input tensor data (confidence values).
@@ -286,13 +262,11 @@ VX_API_ENTRY vx_node VX_API_CALL vxTensorMaxNode(vx_graph graph, vx_tensor input
  * \return <tt> vx_node</tt>.
  * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
-VX_API_ENTRY vx_node VX_API_CALL vxDetectionOutputLayer(vx_graph graph, vx_tensor input1, vx_tensor input2, vx_tensor input3, vx_int32 num_classes, vx_int32 share_location, vx_int32 background_label_id, vx_float32 nms_threshold,
-                                                        vx_int32 code_type, vx_int32 keep_top_k, vx_int32 variance_encoded_in_target, vx_tensor output);
+VX_API_ENTRY vx_node VX_API_CALL vxDetectionOutputLayer(vx_graph graph, vx_tensor input1, vx_tensor input2, vx_tensor input3, vx_int32 num_classes, vx_int32 share_location, vx_int32 background_label_id, vx_float32 nms_threshold, vx_int32 code_type, vx_int32 keep_top_k, vx_int32 variance_encoded_in_target, vx_tensor output);
 
 /*! \brief [Graph] Creates a Cast Layer Node.
  * \ingroup group_amd_nn
- * \details Converts all the elements of the input tensor to the data type specified by input_2 of the node.\n
- * This function supports 2D or 4D tensors as input and output.
+ * \details Converts all the elements of the input tensor to the data type specified by input_2 of the node. This function supports 2D or 4D tensors as input and output.
  * \param [in] graph The handle to the graph.
  * \param [in] input The input tensor data. Can be VX_TYPE_FLOAT32, VX_TYPE_INT32, VX_TYPE_INT64.
  * \param [in] output_data_type The required output tensor data type. Integer value between 0-13.
@@ -305,8 +279,7 @@ VX_API_ENTRY vx_node VX_API_CALL vxCastLayer(vx_graph graph, vx_tensor input, vx
 
 /*! \brief [Graph] Creates a Tensor_Exp Layer Node.
  * \ingroup group_amd_nn
- * \details Calculates the element-wise exponential of the element values in the input <tt>\ref vx_tensor</tt>.
- * This function supports 4D tensors as input and ouput. The type of the tensor can be either float32 or float16.
+ * \details Calculates the element-wise exponential of the element values in the input <tt>\ref vx_tensor</tt>. This function supports 4D tensors as input and ouput. The type of the tensor can be either float32 or float16.
  * \param [in] graph The handle to the graph.
  * \param [in] input The input tensor data.
  * \param [out] output The output tensor data with the same dimensions as the input tensor data.
@@ -317,8 +290,7 @@ VX_API_ENTRY vx_node VX_API_CALL vxTensorExpNode(vx_graph graph, vx_tensor input
 
 /*! \brief [Graph] Creates a Tensor_Log Layer Node.
  * \ingroup group_amd_nn
- * \details Calculates the element-wise natural log of the element values in the input <tt>\ref vx_tensor</tt>.
- * This function supports 4D tensors as input and ouput. The type of the tensor can be either float32 or float16.
+ * \details Calculates the element-wise natural log of the element values in the input <tt>\ref vx_tensor</tt>. This function supports 4D tensors as input and ouput. The type of the tensor can be either float32 or float16.
  * \param [in] graph The handle to the graph.
  * \param [in] input The input tensor data.
  * \param [out] output The output tensor data with the same dimensions as the input tensor data.
@@ -329,30 +301,28 @@ VX_API_ENTRY vx_node VX_API_CALL vxTensorLogNode(vx_graph graph, vx_tensor input
 
 /*! \brief [Graph] Creates a Non Max Suppression Layer Node.
  * \ingroup group_amd_nn
- * \details Filter out boxes that have high intersection-over-union (IOU) overlap with previously selected boxes.
- * This function supports 4D tensors as input and ouput. The type of the tensor is int64.
+ * \details Filter out boxes that have high intersection-over-union (IOU) overlap with previously selected boxes. This function supports 4D tensors as input and ouput. The type of the tensor is int64.
  * \param [in] graph The handle to the graph.
  * \param [in] boxes The input tensor data which has coordinates for all the bounding boxes.
  * \param [in] scores The input tensor data which has scores for all the bounding boxes.
  * \param [in] center_point_box The input scalar data which tells the format of the coordinates of bounding boxes.
+ * \param [out] output The output tensor data with the dimensions based on the number of selected boxes.
  * \param [in] max_output_boxes_per_class The input tensor int64 data representing the maximum number of boxes to be selected per batch per class.
  * \param [in] iou_threshold The input tensor float data representing the maximum number of boxes to be selected per batch per class.
  * \param [in] score_threshold The input tensor float data representing the threshold for deciding when to remove boxes based on score.
- * \param [out] output The output tensor data with the dimensions based on the number of selected boxes.
  * \return <tt> vx_node</tt>.
  * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
-VX_API_ENTRY vx_node VX_API_CALL vxNMSLayer(vx_graph graph, vx_tensor boxes, vx_tensor scores, vx_int32 center_point_box, vx_tensor output, vx_tensor max_output_boxes_per_class,
-                                            vx_tensor iou_threshold, vx_tensor score_threshold);
+VX_API_ENTRY vx_node VX_API_CALL vxNMSLayer(vx_graph graph, vx_tensor boxes, vx_tensor scores, vx_int32 center_point_box, vx_tensor output, vx_tensor max_output_boxes_per_class, vx_tensor iou_threshold, vx_tensor score_threshold);
 
 /*! \brief [Graph] Creates a Gather Layer Node.
  * \ingroup group_amd_nn
- * \details Given data tensor of rank r >= 1, and indices tensor of rank q, gather entries of the axis dimension of data (by default outer-most one as axis=0)
- * indexed by indices, and concatenates them in an output tensor of rank q + (r - 1).
+ * \details Given data tensor of rank r >= 1, and indices tensor of rank q, gather entries of the axis dimension of data (by default outer-most one as axis=0) indexed by indices, and concatenates them in an output tensor of rank q + (r - 1).
  * \param [in] graph The handle to the graph.
  * \param [in] input The input tensor data to gather elements on. The type of the tensor can be either float32 or float16.
  * \param [in] indices The indices tensor containing the index data. The type of the tensor can be either int32 or int64.
  * \param [out] output The output tensor data with the same type as the input tensor data.
+ * \param [in] axis The axis vx_int32 data.
  * \return <tt> vx_node</tt>.
  * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
@@ -360,18 +330,19 @@ VX_API_ENTRY vx_node VX_API_CALL vxGatherLayer(vx_graph graph, vx_tensor input, 
 
 /*! \brief [Graph] Creates a TopK Layer Node.
  * \ingroup group_amd_nn
- * \details Retrieve the top-K largest or smallest elements along a specified axis
- * This function supports 4D tensors as input and ouput.
+ * \details Retrieve the top-K largest or smallest elements along a specified axis. This function supports 4D tensors as input and ouput.
  * \param [in] graph The handle to the graph.
  * \param [in] x_tensor The input tensor data.
  * \param [in] k_tensor The 1-D input tensor data containing a single positive value corresponding to the number of top elements to retrieve.
+ * \param [in] axis The axis vx_int32 data.
+ * \param [in] largest The largest vx_int32 data.
+ * \param [in] sorted The sorted vx_int32 data
  * \param [out] values The output tensor data containing top K values from the input 'x_tensor'.
  * \param [out] indices The output tensor data containing the corresponding input tensor indices for the top K values.
  * \return <tt> vx_node</tt>.
  * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */
-VX_API_ENTRY vx_node VX_API_CALL vxTopKLayer(vx_graph graph, vx_tensor x_tensor, vx_tensor k_tensor, vx_int32 axis, vx_int32 largest, vx_int32 sorted,
-                                             vx_tensor values, vx_tensor indices);
+VX_API_ENTRY vx_node VX_API_CALL vxTopKLayer(vx_graph graph, vx_tensor x_tensor, vx_tensor k_tensor, vx_int32 axis, vx_int32 largest, vx_int32 sorted, vx_tensor values, vx_tensor indices);
 
 /*! \brief [Graph] Creates a Reduce Min Layer Node.
  * \ingroup group_amd_nn
@@ -400,21 +371,12 @@ VX_API_ENTRY vx_node VX_API_CALL vxTileLayer(vx_graph graph, vx_tensor input, vx
 
 /*! \brief [Graph] Creates a Tensor Compare Node.
  * \ingroup group_amd_nn
- * \details Returns the tensor resulted from performing the comparison operation elementwise on the input tensors A and B
- * This function supports 4D tensors as input and ouput.
+ * \details Returns the tensor resulted from performing the comparison operation elementwise on the input tensors A and B. This function supports 4D tensors as input and ouput.
  * \param [in] graph The handle to the graph.
  * \param [in] input The first input tensor data.
  * \param [in] input2 The second input tensor data.
  * \param [out] output The output tensor data with the same dimensions as the input tensor data. The type of the output is constraint to boolean.
- * \param [in] mode The mode value for the comparison.
- *  @note Supports the following mode values:
- *       - 0 - Less than (<)
- *       - 1 - Greater than (>)
- *       - 2 - Less than or equal to (<=)
- *       - 3 - Greater than or equal to (>=)
- *       - 4 - Equal to (==)
- *       - 5 - Not equal to (!=)
- *
+ *  @note Supports the following mode values: - 0 - Less than (<) - 1 - Greater than (>) - 2 - Less than or equal to (<=) - 3 - Greater than or equal to (>=) - 4 - Equal to (==) - 5 - Not equal to (!=)
  * \return <tt> vx_node</tt>.
  * \returns A node reference <tt>\ref vx_node</tt>. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>.
  */

--- a/amd_openvx_extensions/amd_opencv/include/vx_ext_opencv.h
+++ b/amd_openvx_extensions/amd_opencv/include/vx_ext_opencv.h
@@ -41,15 +41,30 @@ THE SOFTWARE.
 #endif
 
 #ifndef dimof
+/*! \def dimof(x)
+ *  \brief A macro to get the number of elements in an array.
+ *  \param [in] x The array whose size is to be determined.
+ *  \return The number of elements in the array.
+ */
 #define dimof(x) (sizeof(x) / sizeof(x[0]))
 #endif
 
 #if _WIN32
 #define SHARED_PUBLIC __declspec(dllexport)
 #else
+/*! \def SHARED_PUBLIC
+ *  \brief A macro to specify public visibility for shared library symbols.
+ */
 #define SHARED_PUBLIC __attribute__((visibility("default")))
 #endif
 
+/*! \brief Creates a node in a graph using a predefined kernel structure.
+ *  \param [in] graph The handle to the graph.
+ *  \param [in] kernelenum The enum value representing the kernel to be used.
+ *  \param [in] params An array of parameter references for the kernel.
+ *  \param [in] num The number of parameters in the params array.
+ *  \return A handle to the created node.
+ */
 vx_node vxCreateNodeByStructure(vx_graph graph, vx_enum kernelenum, vx_reference params[], vx_uint32 num);
 
 #ifdef __cplusplus
@@ -70,7 +85,7 @@ extern "C"
 	 * \param [in] kheight The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set normalized box filter height.
 	 * \param [in] Anchor_X The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set anchor point x.
 	 * \param [in] Anchor_Y The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set anchor point y.
-	 * \param [in] Border_Type The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set borderType.
+	 * \param [in] Bordertype The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set borderType.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
 	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtCvNode_blur(vx_graph graph, vx_image input, vx_image output, vx_uint32 kwidth, vx_uint32 kheight, vx_int32 Anchor_X, vx_int32 Anchor_Y, vx_int32 Bordertype);
@@ -83,6 +98,10 @@ extern "C"
 	 * \param [in] ddepth The input <tt>\ref VX_TYPE_INT32</tt> scalar to set output image depth.
 	 * \param [in] kwidth The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set box filter width.
 	 * \param [in] kheight The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set box filter height.
+	 * \param [in] Anchor_X The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set anchor point x.
+	 * \param [in] Anchor_Y The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set anchor point y.
+	 * \param [in] Normalized The input <tt>\ref VX_TYPE_BOOL</tt> scalar for Normalized argument.
+	 * \param [in] Bordertype The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set borderType.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
 	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtCvNode_boxFilter(vx_graph graph, vx_image input, vx_image output, vx_int32 ddepth, vx_uint32 kwidth, vx_uint32 kheight, vx_int32 Anchor_X, vx_int32 Anchor_Y, vx_bool Normalized, vx_int32 Bordertype);
@@ -145,12 +164,12 @@ extern "C"
 	/*! \brief [Graph] Creates a OpenCV BilateralFilter function node.
 	 * \ingroup group_opencv
 	 * \param [in] graph The reference to the graph.
-	 * \param [in] input The input image in <tt>\ref VX_DF_IMAGE_U8</tt>  format.
+	 * \param [in] input The input image in <tt>\ref VX_DF_IMAGE_U8</tt> format.
 	 * \param [out] output The output image is as same size and type of input.
 	 * \param [in] d The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set K width.
-	 * \param [in] sigmaColor The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar to set sigmaX.
-	 * \param [in] sigmaSpace The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar to set sigmaY.
-	 * \param [in] Border mode The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set border mode.
+	 * \param [in] Sigma_Color The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar to set sigmaX.
+	 * \param [in] Sigma_Space The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar to set sigmaY.
+	 * \param [in] border_mode mode The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set border mode.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
 	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtCvNode_bilateralFilter(vx_graph graph, vx_image input, vx_image output, vx_uint32 d, vx_float32 Sigma_Color, vx_float32 Sigma_Space, vx_int32 border_mode);
@@ -232,13 +251,16 @@ extern "C"
 	 * \ingroup group_opencv
 	 * \param [in] graph The reference to the graph.
 	 * \param [in] input The input image in <tt>\ref VX_DF_IMAGE_U8</tt> format.
-	 * \param [in] input_kp The output keypoints <tt>\ref vx_array</tt> of <tt>\ref VX_TYPE_KEYPOINT</tt>.
+	 * \param [in] mask The mask image in <tt>\ref VX_DF_IMAGE_U8</tt> format (optional).
+	 * \param [in] output_kp The output keypoints <tt>\ref vx_array</tt> of <tt>\ref VX_TYPE_KEYPOINT</tt>.
 	 * \param [out] output_des The output descriptors <tt>\ref vx_array</tt> of user defined data type with 64/128 byte element size depending upon extended argument.
+	 * \param [in] nfeatures The input <tt>\ref VX_TYPE_INT32</tt> scalar for nfeatures argument.
 	 * \param [in] scaleFactor The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar for scaleFactor argument.
 	 * \param [in] nlevels The input <tt>\ref VX_TYPE_INT32</tt> scalar for nlevels argument.
 	 * \param [in] edgeThreshold The input <tt>\ref VX_TYPE_INT32</tt> scalar for edgeThreshold argument.
 	 * \param [in] firstLevel The input <tt>\ref VX_TYPE_INT32</tt> scalar for firstLevel argument.
 	 * \param [in] WTA_K The input <tt>\ref VX_TYPE_INT32</tt> scalar for WTA_K argument.
+	 * \param [in] scoreType The input <tt>\ref VX_TYPE_INT32</tt> scalar for scoreType argument.
 	 * \param [in] patchSize The input <tt>\ref VX_TYPE_INT32</tt> scalar for patchSize argument.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
@@ -250,7 +272,6 @@ extern "C"
 	 * \param [in] input The input image in <tt>\ref VX_DF_IMAGE_U8</tt> format.
 	 * \param [in] mask The mask image in <tt>\ref VX_DF_IMAGE_U8</tt> format (optional).
 	 * \param [out] output_kp The output keypoints <tt>\ref vx_array</tt> of <tt>\ref VX_TYPE_KEYPOINT</tt>.
-	 * \param [out] output_des The output descriptors <tt>\ref vx_array</tt> of user defined data type with 64/128 byte element size depending upon extended argument (optional).
 	 * \param [in] nfeatures The input <tt>\ref VX_TYPE_INT32</tt> scalar for nfeatures argument.
 	 * \param [in] scaleFactor The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar for scaleFactor argument.
 	 * \param [in] nlevels The input <tt>\ref VX_TYPE_INT32</tt> scalar for nlevels argument.
@@ -267,9 +288,13 @@ extern "C"
 	 * \ingroup group_opencv
 	 * \param [in] graph The reference to the graph.
 	 * \param [in] input The input image in <tt>\ref VX_DF_IMAGE_U8</tt> format.
-	 * \param [in] input_kp The input keypoints <tt>\ref vx_array</tt> of <tt>\ref VX_TYPE_KEYPOINT</tt>.
+	 * \param [in] mask The mask image in <tt>\ref VX_DF_IMAGE_U8</tt> format (optional).
+	 * \param [in] output_kp The output keypoints <tt>\ref vx_array</tt> of <tt>\ref VX_TYPE_KEYPOINT</tt>.
 	 * \param [out] output_des The output descriptors <tt>\ref vx_array</tt> of user defined data type with 128 byte element size.
+	 * \param [in] nfeatures The input <tt>\ref VX_TYPE_INT32</tt> scalar for nfeatures argument.
 	 * \param [in] nOctaveLayers The input <tt>\ref VX_TYPE_INT32</tt> scalar for nOctaveLayers argument.
+	 * \param [in] contrastThreshold The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar for contrastThreshold argument.
+	 * \param [in] edgeThreshold The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar for edgeThreshold argument.
 	 * \param [in] sigma The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar for sigma argument.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
@@ -281,7 +306,6 @@ extern "C"
 	 * \param [in] input The input image in <tt>\ref VX_DF_IMAGE_U8</tt> format.
 	 * \param [in] mask The mask image in <tt>\ref VX_DF_IMAGE_U8</tt> format (optional).
 	 * \param [out] output_kp The output keypoints <tt>\ref vx_array</tt> of <tt>\ref VX_TYPE_KEYPOINT</tt>.
-	 * \param [out] output_des The output descriptors <tt>\ref vx_array</tt> of user defined data type with 128 byte element size (optional).
 	 * \param [in] nfeatures The input <tt>\ref VX_TYPE_INT32</tt> scalar for nfeatures argument. Set this to capacity of output_kp to retain best keypoints.
 	 * \param [in] nOctaveLayers The input <tt>\ref VX_TYPE_INT32</tt> scalar for nOctaveLayers argument.
 	 * \param [in] contrastThreshold The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar for contrastThreshold argument.
@@ -320,8 +344,12 @@ extern "C"
 	 * \ingroup group_opencv
 	 * \param [in] graph The reference to the graph.
 	 * \param [in] input The input image in <tt>\ref VX_DF_IMAGE_U8</tt> format.
-	 * \param [in] input_kp The input keypoints <tt>\ref vx_array</tt> of <tt>\ref VX_TYPE_KEYPOINT</tt>.
+	 * \param [in] mask The mask image in <tt>\ref VX_DF_IMAGE_U8</tt> format (optional).
+	 * \param [in] output_kp The output keypoints <tt>\ref vx_array</tt> of <tt>\ref VX_TYPE_KEYPOINT</tt>.
 	 * \param [out] output_des The output descriptors <tt>\ref vx_array</tt> of user defined data type with 64/128 byte element size depending upon extended argument.
+	 * \param [in] hessianThreshold The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar for hessianThreshold argument.
+	 * \param [in] nOctaves The input <tt>\ref VX_TYPE_INT32</tt> scalar for nOctaves argument.
+	 * \param [in] nOctaveLayers The input <tt>\ref VX_TYPE_INT32</tt> scalar for nOctaveLayers argument.
 	 * \param [in] extended The input <tt>\ref VX_TYPE_BOOL</tt> scalar for extended argument.
 	 * \param [in] upright The input <tt>\ref VX_TYPE_BOOL</tt> scalar for upright argument.
 	 * \return <tt>\ref vx_node</tt>.
@@ -338,8 +366,6 @@ extern "C"
 	 * \param [in] hessianThreshold The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar for hessianThreshold argument.
 	 * \param [in] nOctaves The input <tt>\ref VX_TYPE_INT32</tt> scalar for nOctaves argument.
 	 * \param [in] nOctaveLayers The input <tt>\ref VX_TYPE_INT32</tt> scalar for nOctaveLayers argument.
-	 * \param [in] extended The input <tt>\ref VX_TYPE_BOOL</tt> scalar for extended argument.
-	 * \param [in] upright The input <tt>\ref VX_TYPE_BOOL</tt> scalar for upright argument.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
 	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtCvNode_surfDetect(vx_graph graph, vx_image input, vx_image mask, vx_array output_kp, vx_array output_des, vx_float32 hessianThreshold, vx_int32 nOctaves, vx_int32 nOctaveLayers);
@@ -378,7 +404,7 @@ extern "C"
 	 * \param [in] graph The reference to the graph.
 	 * \param [in] input The input image in <tt>\ref VX_DF_IMAGE_U8</tt> format.
 	 * \param [out] norm_value The output <tt>\ref VX_TYPE_FLOAT32</tt> scalar norm_value.
-	 * \param [in] sdepth The input <tt>\ref VX_TYPE_INT32</tt> scalar to set sdepth.
+	 * \param [in] norm_type The input <tt>\ref VX_TYPE_INT32</tt> scalar to set norm_type.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
 	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtCvNode_norm(vx_graph graph, vx_image input, vx_float32 norm_value, vx_int32 norm_type);
@@ -458,7 +484,7 @@ extern "C"
 	 * \param [in] dtype The input <tt>\ref VX_TYPE_INT32</tt> scalar to set dtype.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
-	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtCvNode_addWeighted(vx_graph graph, vx_image imput_1, vx_float32 aplha, vx_image input_2, vx_float32 beta, vx_float32 gamma, vx_image output, vx_int32 dtype);
+	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtCvNode_addWeighted(vx_graph graph, vx_image input_1, vx_float32 aplha, vx_image input_2, vx_float32 beta, vx_float32 gamma, vx_image output, vx_int32 dtype);
 
 	/*! \brief [Graph] Creates a OpenCV adaptiveThreshold function node.
 	 * \ingroup group_opencv
@@ -573,7 +599,6 @@ extern "C"
 	 * \param [in] graph The reference to the graph.
 	 * \param [in] input The input image in <tt>\ref VX_DF_IMAGE_U8</tt> format.
 	 * \param [out] output The output Pyramid.
-	 * \param [in] OP The input <tt>\ref VX_TYPE_INT32</tt> scalar to set OP.
 	 * \param [in] maxLevel The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set maxLevel.
 	 * \param [in] border The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set border.
 	 * \return <tt>\ref vx_node</tt>.
@@ -585,13 +610,13 @@ extern "C"
 	 * \param [in] graph The reference to the graph.
 	 * \param [in] input The input image in <tt>\ref VX_DF_IMAGE_U8</tt> format.
 	 * \param [out] output The output Pyramid.
-	 * \param [in] WIN_Size_Width The input <tt>\ref VX_TYPE_INT32</tt> scalar to set WIN_Size_Width.
-	 * \param [in] WIN_Size_Height The input <tt>\ref VX_TYPE_INT32</tt> scalar to set WIN_Size_Height.
-	 * \param [in] maxLevel The input <tt>\ref VX_TYPE_INT32</tt> scalar to set maxLevel.
-	 * \param [in] withDerivatives The input <tt>\ref VX_TYPE_BOOL</tt> scalar to set withDerivatives.
-	 * \param [in] pyrBorder The input <tt>\ref VX_TYPE_INT32</tt> scalar to set pyrBorder.
-	 * \param [in] derivBorder The input <tt>\ref VX_TYPE_INT32</tt> scalar to set derivBorder.
-	 * \param [in] tryReuseInputImage The input <tt>\ref VX_TYPE_BOOL</tt> scalar to set tryReuseInputImage.
+	 * \param [in] S_width The input <tt>\ref VX_TYPE_INT32</tt> scalar to set S_width.
+	 * \param [in] S_height The input <tt>\ref VX_TYPE_INT32</tt> scalar to set S_height.
+	 * \param [in] WinSize The input <tt>\ref VX_TYPE_INT32</tt> scalar to set WinSize.
+	 * \param [in] WithDerivatives The input <tt>\ref VX_TYPE_BOOL</tt> scalar to set withDerivatives.
+	 * \param [in] Pyr_border The input <tt>\ref VX_TYPE_INT32</tt> scalar to set Pyr_border.
+	 * \param [in] derviBorder The input <tt>\ref VX_TYPE_INT32</tt> scalar to set derviBorder.
+	 * \param [in] tryReuse The input <tt>\ref VX_TYPE_BOOL</tt> scalar to set tryReuseInputImage.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
 	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtCvNode_buildOpticalFlowPyramid(vx_graph graph, vx_image input, vx_pyramid output, vx_uint32 S_width, vx_uint32 S_height, vx_int32 WinSize, vx_bool WithDerivatives, vx_int32 Pyr_border, vx_int32 derviBorder, vx_bool tryReuse);
@@ -714,7 +739,7 @@ extern "C"
 	 * \param [in] threshold1 The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar to set threshold1.
 	 * \param [in] threshold2 The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar to set threshold2.
 	 * \param [in] aperture_size The input <tt>\ref VX_TYPE_INT32</tt> scalar to set aperture_size.
-	 * \param [in] L2_Gradient The input <tt>\ref VX_BOOL</tt> scalar to set L2_Gradient.
+	 * \param [in] L2_Gradient The input <tt>\ref VX_TYPE_BOOL</tt> scalar to set L2_Gradient.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
 	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtCvNode_canny(vx_graph graph, vx_image input, vx_image output, vx_float32 threshold1, vx_float32 threshold2, vx_int32 aperture_size, vx_bool L2_Gradient);
@@ -733,8 +758,8 @@ extern "C"
 	/*! \brief [Graph] Creates a OpenCV convertScaleAbs function node.
 	 * \ingroup group_opencv
 	 * \param [in] graph The reference to the graph.
-	 * \param [in] input The input image in <tt>\ref VX_DF_IMAGE_U8</tt>  format.
-	 * \param [out] output The output image is as same size and type of input.
+	 * \param [in] image_in The input image in <tt>\ref VX_DF_IMAGE_U8</tt> format.
+	 * \param [out] image_out The output image is as same size and type of input.
 	 * \param [in] alpha The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar to set alpha.
 	 * \param [in] beta The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar to set beta.
 	 * \return <tt>\ref vx_node</tt>.
@@ -748,7 +773,7 @@ extern "C"
 	 * \param [out] output The output image is as same size and type of input.
 	 * \param [in] blocksize The input <tt>\ref VX_TYPE_INT32</tt> scalar to set blocksize.
 	 * \param [in] ksize The input <tt>\ref VX_TYPE_INT32</tt> scalar to set ksize.
-	 * \param [in] K The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar to set K.
+	 * \param [in] k The input <tt>\ref VX_TYPE_FLOAT32</tt> scalar to set K.
 	 * \param [in] border The input <tt>\ref VX_TYPE_INT32</tt> scalar to set border.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
@@ -759,7 +784,7 @@ extern "C"
 	 * \param [in] graph The reference to the graph.
 	 * \param [in] input The input image in <tt>\ref VX_DF_IMAGE_U8</tt> format.
 	 * \param [out] output The output image is as same size and type of input.
-	 * \param [in] blocksize The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set blocksize.
+	 * \param [in] blockSize The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set blocksize.
 	 * \param [in] ksize The input <tt>\ref VX_TYPE_UINT32</tt> scalar to set ksize.
 	 * \param [in] border The input <tt>\ref VX_TYPE_INT32</tt> scalar to set border.
 	 * \return <tt>\ref vx_node</tt>.

--- a/amd_openvx_extensions/amd_winml/include/vx_ext_winml.h
+++ b/amd_openvx_extensions/amd_winml/include/vx_ext_winml.h
@@ -39,15 +39,30 @@ THE SOFTWARE.
  */
 
 #ifndef dimof
+/*! \def dimof(x)
+ *  \brief A macro to get the number of elements in an array.
+ *  \param [in] x The array whose size is to be determined.
+ *  \return The number of elements in the array.
+ */
 #define dimof(x) (sizeof(x) / sizeof(x[0]))
 #endif
 
 #if _WIN32
 #define SHARED_PUBLIC __declspec(dllexport)
 #else
+/*! \def SHARED_PUBLIC
+ *  \brief A macro to specify public visibility for shared library symbols.
+ */
 #define SHARED_PUBLIC __attribute__((visibility("default")))
 #endif
 
+/*! \brief Creates a node in a graph using a predefined kernel structure.
+ *  \param [in] graph The handle to the graph.
+ *  \param [in] kernelenum The enum value representing the kernel to be used.
+ *  \param [in] params An array of parameter references for the kernel.
+ *  \param [in] num The number of parameters in the array.
+ *  \return A handle to the created node.
+ */
 vx_node vxCreateNodeByStructure(vx_graph graph, vx_enum kernelenum, vx_reference params[], vx_uint32 num);
 
 #ifdef __cplusplus
@@ -63,50 +78,36 @@ extern "C"
 	 * \ingroup group_amd_winml
 	 * @note Kernel Name: com.winml.onnx_to_mivisionx
 	 * \param [in] graph The reference to the graph.
-	 * \param [in] input_1 The ONNX Model Location in vx_scalar.
-	 * \param [in] input_2 The ONNX Model Input Tensor Name in vx_scalar.
-	 * \param [in] input_3 The ONNX Model Output Tensor Name in vx_scalar.
-	 * \param [in] input_4 The Input Tensor in <tt>\ref VX_FLOAT32</tt> format.
-	 * \param [in] input_5 The setup Array for each model in <tt>\ref VX_TYPE_SIZE</tt> format.
-	 * \param [out] output The output Tensor in <tt>\ref VX_FLOAT32</tt> format.
-	 * \param [in] input_6 WinML Deploy Device Kind in vx_scalar [optional] (default: 0).
+	 * \param [in] modelLocation The ONNX Model Location in vx_scalar.
+	 * \param [in] inputTensorName The ONNX Model Input Tensor Name in vx_scalar.
+	 * \param [in] outputTensorName The ONNX Model Output Tensor Name in vx_scalar.
+	 * \param [in] inputTensor The Input Tensor.
+	 * \param [in] setupArray The setup Array for each model in <tt>\ref VX_TYPE_SIZE</tt> format.
+	 * \param [out] outputTensor The output Tensor.
+	 * \param [in] deviceKind WinML Deploy Device Kind in vx_scalar [optional] (default: 0).
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
-	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtWinMLNode_OnnxToMivisionX(
-		vx_graph graph,
-		vx_scalar modelLocation,
-		vx_scalar inputTensorName,
-		vx_scalar outputTensorName,
-		vx_tensor inputTensor,
-		vx_array setupArray,
-		vx_tensor outputTensor,
-		vx_scalar deviceKind);
+	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtWinMLNode_OnnxToMivisionX(vx_graph graph, vx_scalar modelLocation, vx_scalar inputTensorName, vx_scalar outputTensorName, vx_tensor inputTensor, vx_array setupArray, vx_tensor outputTensor, vx_scalar deviceKind);
 
 	/*! \brief [Graph] Creates a WinML convert image to tensor node.
 	 * \ingroup group_amd_winml
 	 * @note Kernel Name: com.winml.convert_image_to_tensor
 	 * \param [in] graph The reference to the graph.
-	 * \param [in] input_1 input image vx_image.
-	 * \param [out]  The output Tensor in <tt>\ref VX_FLOAT32</tt> format.
-	 * \param [in] input_2 a in vx_scalar.
-	 * \param [in] input_3 b in vx_scalar.
-	 * \param [in] input_4 reverse channel order in vx_scalar.
+	 * \param [in] input input image vx_image.
+	 * \param [out] output The output Tensor.
+	 * \param [in] a a in vx_scalar.
+	 * \param [in] b b in vx_scalar.
+	 * \param [in] reverse_channel_order reverse channel order in vx_scalar.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
-	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtWinMLNode_convertImageToTensor(
-		vx_graph graph,
-		vx_image input,
-		vx_tensor output,
-		vx_scalar a,
-		vx_scalar b,
-		vx_scalar reverse_channel_order);
+	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtWinMLNode_convertImageToTensor(vx_graph graph, vx_image input, vx_tensor output, vx_scalar a, vx_scalar b, vx_scalar reverse_channel_order);
 
 	/*! \brief [Graph] Creates a output tensor to Top K labels node.
 	 * \ingroup group_amd_winml
 	 * @note Kernel Name: com.winml.get_top_k_labels
 	 * \param [in] graph The reference to the graph.
-	 * \param [in] input_1 probability tensor vx_tensor.
-	 * \param [in] input_2 label text file location vx_scalar.
+	 * \param [in] prob_tensor probability tensor vx_tensor.
+	 * \param [in] labelFile label text file location vx_scalar.
 	 * \param [out] output_1 Top 1 in vx_scalar.
 	 * \param [out] output_2 Top 2 in vx_scalar. [optional]
 	 * \param [out] output_3 Top 3 in vx_scalar. [optional]
@@ -114,15 +115,7 @@ extern "C"
 	 * \param [out] output_5 Top 5 in vx_scalar. [optional]
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/
-	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtWinMLNode_getTopKLabels(
-		vx_graph graph,
-		vx_tensor prob_tensor,
-		vx_scalar labelFile,
-		vx_scalar output_1,
-		vx_scalar output_2,
-		vx_scalar output_3,
-		vx_scalar output_4,
-		vx_scalar output_5);
+	extern "C" SHARED_PUBLIC vx_node VX_API_CALL vxExtWinMLNode_getTopKLabels(vx_graph graph, vx_tensor prob_tensor, vx_scalar labelFile, vx_scalar output_1, vx_scalar output_2, vx_scalar output_3, vx_scalar output_4, vx_scalar output_5);
 
 #ifdef __cplusplus
 }

--- a/amd_openvx_extensions/amd_winml/include/vx_ext_winml.h
+++ b/amd_openvx_extensions/amd_winml/include/vx_ext_winml.h
@@ -95,8 +95,8 @@ extern "C"
 	 * \param [in] graph The reference to the graph.
 	 * \param [in] input input image vx_image.
 	 * \param [out] output The output Tensor.
-	 * \param [in] a a in vx_scalar.
-	 * \param [in] b b in vx_scalar.
+	 * \param [in] a The input 'a' in vx_scalar.
+	 * \param [in] b The input 'b' in vx_scalar.
 	 * \param [in] reverse_channel_order reverse channel order in vx_scalar.
 	 * \return <tt>\ref vx_node</tt>.
 	 * \retval vx_node A node reference. Any possible errors preventing a successful creation should be checked using <tt>\ref vxGetStatus</tt>*/


### PR DESCRIPTION
MCW formatted code for rocAL which fixed warnings for other extensions. Cherry picking non rocAL/RPP changes to fix warnings,