### PR TITLE
MIVisionX ASAN - Exclude library_tests from ASAN pkg

### DIFF
--- a/tests/openvx_api_tests/CMakeLists.txt
+++ b/tests/openvx_api_tests/CMakeLists.txt
@@ -26,7 +26,9 @@
 cmake_minimum_required(VERSION 3.5)
 
 # TBD - Install additional data indepedent tests
-install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../library_tests DESTINATION ${CMAKE_INSTALL_DATADIR}/mivisionx/tests)
+if(NOT ENABLE_ASAN_PACKAGING)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/../library_tests DESTINATION ${CMAKE_INSTALL_DATADIR}/mivisionx/tests)
+endif()
 
 # default run
 # canny


### PR DESCRIPTION
Changes Proposed:

- Exclude test files from MIVisionX ASAN package.
- Fix for SWDEV-430827